### PR TITLE
SKINNY-128 and ForkSkinny could not decrypt what they encrypted

### DIFF
--- a/Cipher/algorithms/block/forkskinny.js
+++ b/Cipher/algorithms/block/forkskinny.js
@@ -529,15 +529,27 @@
 
       // Test vectors from reference implementation
       //
-      // The left-output value was previously recorded as 32411c5ca70baf92...,
-      // which is what this file produced before the tweakey schedule was carried
-      // across the skipped right branch. That value cannot be right: C0 depends
-      // only on the tweakey and the message, yet it disagreed with the C0 the
-      // very same code computes when both outputs are requested. The combined
-      // path is pinned by NIST LWC vector #34 for PAEF-ForkSkinny-128-256
+      // The left output was previously recorded as 32411c5ca70baf92..., taken
+      // from the "Left" case of the cited reference test file. That file also
+      // carries a "Both Left" case holding 1078c53597fc5e4c9d91a8eae8f5a876 for
+      // the same key and message, and the two disagree. Only one can be right:
+      // C0 is a function of the tweakey and the message alone, so it cannot
+      // depend on whether the caller also asked for C1.
+      //
+      // The combined value is the correct one. The reference encrypt routine
+      // advances the tweakey schedule only as a side effect of computing the
+      // right branch, so when it is called without a right output it applies the
+      // branching constant and runs rounds r_init+r_1 .. r_init+r_1+r_0-1 with
+      // the tweakey still parked at r_init, leaving round constants and tweakey
+      // out of step. Its own "Invert Left" decryption cases round-trip the
+      // combined value, not the left-only one.
+      //
+      // Independently pinned by NIST LWC vector #34 for PAEF-ForkSkinny-128-256
       // (1-byte plaintext, empty AAD), whose ciphertext block is exactly the C0
-      // of the padded message block, so the combined path is the correct one and
-      // the left-only value below now matches it.
+      // of the padded message block and matches the combined value; and by the
+      // official ForkAE KATs, where the advanced-tweakey reading passes all 40
+      // while the non-advanced reading fails precisely the vectors that exercise
+      // the left branch.
       const OC = typeof OpCodes !== 'undefined' ? OpCodes : global.OpCodes;
       this.tests = [
         {
@@ -859,8 +871,9 @@
           input: OC.Hex8ToBytes("00112233445566778899aabbccddeeff"),
           key: OC.Hex8ToBytes("000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f"),
           // Corrected alongside the 128-256 left output above, for the same
-          // reason: the left branch continues the tweakey schedule after the
-          // right branch, so left-only and combined must agree.
+          // reason and from the same source: the reference test file's "Both
+          // Left" case, rather than its "Left" case, which was produced without
+          // advancing the tweakey across the skipped right branch.
           expected: OC.Hex8ToBytes("a842dcd53062730d8e293cd923ef9aa9"),
           forkOutput: "left"
         },

--- a/Cipher/algorithms/block/forkskinny.js
+++ b/Cipher/algorithms/block/forkskinny.js
@@ -528,6 +528,16 @@
       ];
 
       // Test vectors from reference implementation
+      //
+      // The left-output value was previously recorded as 32411c5ca70baf92...,
+      // which is what this file produced before the tweakey schedule was carried
+      // across the skipped right branch. That value cannot be right: C0 depends
+      // only on the tweakey and the message, yet it disagreed with the C0 the
+      // very same code computes when both outputs are requested. The combined
+      // path is pinned by NIST LWC vector #34 for PAEF-ForkSkinny-128-256
+      // (1-byte plaintext, empty AAD), whose ciphertext block is exactly the C0
+      // of the padded message block, so the combined path is the correct one and
+      // the left-only value below now matches it.
       const OC = typeof OpCodes !== 'undefined' ? OpCodes : global.OpCodes;
       this.tests = [
         {
@@ -535,7 +545,7 @@
           uri: "https://github.com/rweather/lightweight-crypto/blob/master/test/unit/test-forkskinny.c",
           input: OC.Hex8ToBytes("00112233445566778899aabbccddeeff"),
           key: OC.Hex8ToBytes("000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"),
-          expected: OC.Hex8ToBytes("32411c5ca70baf9249514b3893254228"),
+          expected: OC.Hex8ToBytes("1078c53597fc5e4c9d91a8eae8f5a876"),
           forkOutput: "left"
         },
         {
@@ -703,6 +713,15 @@
           state.S[1] = F_S[1];
           state.S[2] = F_S[2];
           state.S[3] = F_S[3];
+        } else {
+          // Left output requested on its own. C0 is a function of the tweakey and
+          // the message alone, so it must not depend on whether the caller also
+          // asked for C1: the ForkAE specification numbers the left branch rounds
+          // r_init+r_1 .. r_init+r_1+r_0-1, i.e. after the right branch. Skipping
+          // the right branch therefore still has to advance the tweakey schedule
+          // across it, otherwise this path yields a different C0 than the
+          // combined path does.
+          forkskinny_128_256_forward_tk(state, FORKSKINNY_128_256_ROUNDS_AFTER);
         }
 
         // Generate left output with branching constant
@@ -743,22 +762,49 @@
       state.S[2] = OpCodes.Pack32LE(input[8], input[9], input[10], input[11]);
       state.S[3] = OpCodes.Pack32LE(input[12], input[13], input[14], input[15]);
 
-      // Fast-forward tweakey to end of schedule
-      const totalRounds = FORKSKINNY_128_256_ROUNDS_BEFORE + FORKSKINNY_128_256_ROUNDS_AFTER * 2;
-      forkskinny_128_256_forward_tk(state, totalRounds);
+      const before = FORKSKINNY_128_256_ROUNDS_BEFORE;
+      const after = FORKSKINNY_128_256_ROUNDS_AFTER;
 
-      // Decrypt left branch in reverse
-      forkskinny_128_256_inv_rounds(state, totalRounds,
-                                    FORKSKINNY_128_256_ROUNDS_BEFORE + FORKSKINNY_128_256_ROUNDS_AFTER);
+      // The two fork outputs are reached by different round ranges, so inversion
+      // has to start from the branch that actually produced this block.
+      if (this._forkOutput === "right") {
+        // C1 is rounds 0 .. before+after applied straight through, with no
+        // branching constant, so one contiguous reverse run recovers M.
+        forkskinny_128_256_forward_tk(state, before + after);
+        forkskinny_128_256_inv_rounds(state, before + after, 0);
+        return this.unpackState(state.S);
+      }
+
+      // C0 path: undo the left branch, strip the branching constant, then roll
+      // the tweakey schedule back across the right branch. Without that rollback
+      // the tweakey sits at round before+after while the initial rounds need it
+      // at round before, and the common rounds are unwound with the wrong keys.
+      const totalRounds = before + after * 2;
+      forkskinny_128_256_forward_tk(state, totalRounds);
+      forkskinny_128_256_inv_rounds(state, totalRounds, before + after);
       state.S[0] ^= BRANCH_CONSTANT[0];
       state.S[1] ^= BRANCH_CONSTANT[1];
       state.S[2] ^= BRANCH_CONSTANT[2];
       state.S[3] ^= BRANCH_CONSTANT[3];
+      forkskinny_128_256_reverse_tk(state, after);
+
+      // "both" reproduces the sibling output C1 from the recovered fork point,
+      // which is what the ForkAE modes need in order to check the tag.
+      let outputRight = null;
+      if (this._forkOutput === "both") {
+        const fstate = new ForkSkinny128_256_State();
+        fstate.S.set(state.S);
+        fstate.TK1.set(state.TK1);
+        fstate.TK2.set(state.TK2);
+        forkskinny_128_256_rounds(fstate, before, before + after);
+        outputRight = this.unpackState(fstate.S);
+      }
 
       // Decrypt common rounds
-      forkskinny_128_256_inv_rounds(state, FORKSKINNY_128_256_ROUNDS_BEFORE, 0);
+      forkskinny_128_256_inv_rounds(state, before, 0);
 
-      return this.unpackState(state.S);
+      const outputLeft = this.unpackState(state.S);
+      return outputRight ? outputLeft.concat(outputRight) : outputLeft;
     }
 
     unpackState(S) {
@@ -812,7 +858,10 @@
           uri: "https://github.com/rweather/lightweight-crypto/blob/master/test/unit/test-forkskinny.c",
           input: OC.Hex8ToBytes("00112233445566778899aabbccddeeff"),
           key: OC.Hex8ToBytes("000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f"),
-          expected: OC.Hex8ToBytes("29260866a85fa181f7c1392fd709296c"),
+          // Corrected alongside the 128-256 left output above, for the same
+          // reason: the left branch continues the tweakey schedule after the
+          // right branch, so left-only and combined must agree.
+          expected: OC.Hex8ToBytes("a842dcd53062730d8e293cd923ef9aa9"),
           forkOutput: "left"
         },
         {
@@ -983,6 +1032,11 @@
           state.S[1] = F_S[1];
           state.S[2] = F_S[2];
           state.S[3] = F_S[3];
+        } else {
+          // See ForkSkinny-128-256 above: the left branch is numbered after the
+          // right branch, so a left-only request still has to advance the
+          // tweakey schedule across the skipped right branch.
+          forkskinny_128_384_forward_tk(state, FORKSKINNY_128_384_ROUNDS_AFTER);
         }
 
         state.S[0] ^= BRANCH_CONSTANT[0];
@@ -1024,19 +1078,41 @@
       state.S[2] = OpCodes.Pack32LE(input[8], input[9], input[10], input[11]);
       state.S[3] = OpCodes.Pack32LE(input[12], input[13], input[14], input[15]);
 
-      const totalRounds = FORKSKINNY_128_384_ROUNDS_BEFORE + FORKSKINNY_128_384_ROUNDS_AFTER * 2;
-      forkskinny_128_384_forward_tk(state, totalRounds);
+      const before = FORKSKINNY_128_384_ROUNDS_BEFORE;
+      const after = FORKSKINNY_128_384_ROUNDS_AFTER;
 
-      forkskinny_128_384_inv_rounds(state, totalRounds,
-                                    FORKSKINNY_128_384_ROUNDS_BEFORE + FORKSKINNY_128_384_ROUNDS_AFTER);
+      // See ForkSkinny-128-256 above for the reasoning behind both the branch
+      // selection and the tweakey rollback.
+      if (this._forkOutput === "right") {
+        forkskinny_128_384_forward_tk(state, before + after);
+        forkskinny_128_384_inv_rounds(state, before + after, 0);
+        return this.unpackState(state.S);
+      }
+
+      const totalRounds = before + after * 2;
+      forkskinny_128_384_forward_tk(state, totalRounds);
+      forkskinny_128_384_inv_rounds(state, totalRounds, before + after);
       state.S[0] ^= BRANCH_CONSTANT[0];
       state.S[1] ^= BRANCH_CONSTANT[1];
       state.S[2] ^= BRANCH_CONSTANT[2];
       state.S[3] ^= BRANCH_CONSTANT[3];
+      forkskinny_128_384_reverse_tk(state, after);
 
-      forkskinny_128_384_inv_rounds(state, FORKSKINNY_128_384_ROUNDS_BEFORE, 0);
+      let outputRight = null;
+      if (this._forkOutput === "both") {
+        const fstate = new ForkSkinny128_384_State();
+        fstate.S.set(state.S);
+        fstate.TK1.set(state.TK1);
+        fstate.TK2.set(state.TK2);
+        fstate.TK3.set(state.TK3);
+        forkskinny_128_384_rounds(fstate, before, before + after);
+        outputRight = this.unpackState(fstate.S);
+      }
 
-      return this.unpackState(state.S);
+      forkskinny_128_384_inv_rounds(state, before, 0);
+
+      const outputLeft = this.unpackState(state.S);
+      return outputRight ? outputLeft.concat(outputRight) : outputLeft;
     }
 
     unpackState(S) {

--- a/Cipher/algorithms/block/hierocrypt3.js
+++ b/Cipher/algorithms/block/hierocrypt3.js
@@ -35,6 +35,24 @@
 
   // ===== ALGORITHM IMPLEMENTATION =====
 
+  // Caution: this is a teaching mock-up of Hierocrypt-3, not the NESSIE cipher,
+  // and it is one-way. _sBox is an ad-hoc arithmetic expression rather than the
+  // Hierocrypt S-box, and it is not a bijection: its first step, b XOR ROTL8(b,1),
+  // is singular over GF(2) because 1+X divides X^8+1, and the remaining steps
+  // narrow it further, so all 256 inputs land on just 32 outputs. Encryption
+  // therefore throws away three bits of every byte in every round and cannot be
+  // inverted. Concretely, under the committed key the two blocks
+  // 00112233445566778899AABBCCDDEEFF and 33112233445566778899AABBCCDDEEFF
+  // encrypt to the identical ciphertext, so _invSBox - which brute-force scans
+  // for the first matching preimage - has no correct answer to return.
+  //
+  // Making this round-trip means implementing the real nested-SPN round function
+  // from the NESSIE specification (bijective S-box, MDS_L and MDS_H diffusion,
+  // and the proper key schedule), which would replace the algorithm rather than
+  // repair an inverse, and would retire the self-generated vector below.
+  // A genuine Hierocrypt-3 already exists in this repository as
+  // "Hierocrypt-3 (DarkCrypt)" in darkcrypt-hierocrypt3.js.
+
 class Hierocrypt3 extends BlockCipherAlgorithm {
   constructor() {
     super();

--- a/Cipher/algorithms/block/skinny128.js
+++ b/Cipher/algorithms/block/skinny128.js
@@ -600,10 +600,18 @@
       }
 
       // Perform all decryption rounds (4 at a time, in reverse order)
-      // C reference uses pattern: (s0,s1,s2,s3), (s1,s2,s3,s0), (s2,s3,s0,s1), (s3,s0,s1,s2)
+      //
+      // Tweakey phase (SKINNY spec, eprint 2016/660 section 2.2, permutation PT):
+      // PT maps the bottom half of the tweakey onto the new top half, so encryption
+      // reads TK1[0..1] on even rounds and then permutes the half at index 2, and
+      // reads TK1[2..3] on odd rounds and then permutes the half at index 0.
+      // Round counts are all multiples of 4, so the last round executed is odd and
+      // its trailing permutation was applied to the half at index 0. Unwinding must
+      // therefore start by inverting index 0 and alternate 0, 2, 0, 2 - the mirror
+      // image of the encryption order.
       for (let round = rounds - 1; round >= 0; round -= 4) {
         // Round 4 inverse (C pattern: s0, s1, s2, s3 with offset 3)
-        skinny128_inv_permute_tk_half(TK1, 2);
+        skinny128_inv_permute_tk_half(TK1, 0);
 
         // Inverse MixColumns
         s0 = OpCodes.Xor32(s0, s3);
@@ -633,7 +641,7 @@
         s3 = skinny128_inv_sbox(s3);
 
         // Round 3 inverse (C pattern: s1, s2, s3, s0 with offset 2)
-        skinny128_inv_permute_tk_half(TK1, 0);
+        skinny128_inv_permute_tk_half(TK1, 2);
 
         s1 = OpCodes.Xor32(s1, s0);
         s0 = OpCodes.Xor32(s0, s2);
@@ -659,7 +667,7 @@
         s0 = skinny128_inv_sbox(s0);
 
         // Round 2 inverse (C pattern: s2, s3, s0, s1 with offset 1)
-        skinny128_inv_permute_tk_half(TK1, 2);
+        skinny128_inv_permute_tk_half(TK1, 0);
 
         s2 = OpCodes.Xor32(s2, s1);
         s1 = OpCodes.Xor32(s1, s3);
@@ -685,7 +693,7 @@
         s1 = skinny128_inv_sbox(s1);
 
         // Round 1 inverse (C pattern: s3, s0, s1, s2 with offset 0)
-        skinny128_inv_permute_tk_half(TK1, 0);
+        skinny128_inv_permute_tk_half(TK1, 2);
 
         s3 = OpCodes.Xor32(s3, s2);
         s2 = OpCodes.Xor32(s2, s0);

--- a/Cipher/tests/RoundTripSuite.js
+++ b/Cipher/tests/RoundTripSuite.js
@@ -451,7 +451,6 @@ const ROUND_TRIP_EXEMPT = new Map([
   ['FROG', 'open defect: decryption does not invert encryption (TestSuite reports 0/1)'],
   ['Hierocrypt-3', 'open defect: decryption does not invert encryption (TestSuite reports 0/1)'],
   ['SC2000', 'open defect: decryption does not invert encryption (TestSuite reports 0/1)'],
-  ['SKINNY-128', 'open defect: decryption does not invert encryption (TestSuite reports 0/2)'],
   ['SPEED', 'open defect: decryption does not invert encryption (TestSuite reports 0/1)'],
   ['LOTUS-AEAD', 'open defect: decryption does not invert encryption (TestSuite reports 0/3)'],
   ['SATURNIN-Short', 'open defect: decryption does not invert encryption (TestSuite reports 0/1)'],

--- a/Cipher/tests/RoundTripSuite.js
+++ b/Cipher/tests/RoundTripSuite.js
@@ -447,7 +447,10 @@ const ROUND_TRIP_EXEMPT = new Map([
   // listed so this sweep stays gating on everything else rather than being
   // switched off. Each needs its decryption path repaired on its own merits.
   ['FROG', 'open defect: decryption does not invert encryption (TestSuite reports 0/1)'],
-  ['Hierocrypt-3', 'open defect: decryption does not invert encryption (TestSuite reports 0/1)'],
+  ['Hierocrypt-3', 'not invertible by construction: its S-box maps all 256 byte values onto only '
+    + '32, so encryption discards three bits per byte per round. 00112233445566778899AABBCCDDEEFF '
+    + 'and 33112233445566778899AABBCCDDEEFF encrypt to the same block under the committed key, so '
+    + 'no decryption function exists. Needs a real Hierocrypt-3 round function, not a repaired inverse'],
   ['SC2000', 'open defect: decryption does not invert encryption (TestSuite reports 0/1)'],
   ['SPEED', 'open defect: decryption does not invert encryption (TestSuite reports 0/1)'],
   ['LOTUS-AEAD', 'open defect: decryption does not invert encryption (TestSuite reports 0/3)'],

--- a/Cipher/tests/RoundTripSuite.js
+++ b/Cipher/tests/RoundTripSuite.js
@@ -446,8 +446,6 @@ const ROUND_TRIP_EXEMPT = new Map([
   // TestSuite reports each of these as a round-trip failure today; they are
   // listed so this sweep stays gating on everything else rather than being
   // switched off. Each needs its decryption path repaired on its own merits.
-  ['ForkSkinny-128-256', 'open defect: decryption does not invert encryption (TestSuite reports 0/2)'],
-  ['ForkSkinny-128-384', 'open defect: decryption does not invert encryption (TestSuite reports 0/2)'],
   ['FROG', 'open defect: decryption does not invert encryption (TestSuite reports 0/1)'],
   ['Hierocrypt-3', 'open defect: decryption does not invert encryption (TestSuite reports 0/1)'],
   ['SC2000', 'open defect: decryption does not invert encryption (TestSuite reports 0/1)'],


### PR DESCRIPTION
Three ciphers could not decrypt what they encrypted. The per-vector suite never
noticed: it grades an algorithm on whether its vectors produce the expected
bytes, and although it computes a `failed-roundtrips` status and prints
`Round-trips Passed: 0/2 (FAILED - REQUIRED)`, the only code reading that status
is a display function. It never reaches the tally.

## SKINNY-128

The inverse tweakey schedule transposed the halves of its permutation. Round
counts are multiples of four, so the last round is odd and its trailing
permutation lands on index 0 — unwinding has to alternate `0,2,0,2`, and the code
repeated the encryption order `2,0,2,0`. Every primitive was ruled out first: the
S-box matches the specification table row for row and inverts over all 256
values, the half-permutation inverts, and LFSR3 inverts LFSR2.

Round-trips 0/2 → 2/2. Both committed vectors unchanged.

## ForkSkinny-128-256 and ForkSkinny-128-384

Three defects on the inverse path: decryption ignored which branch produced the
ciphertext and always unwound the left one; the tweakey was never rolled back
across the fork, though the function to do it already existed in the file and was
simply never called; and combined mode never returned the sibling output.

Encryption shared one — asking for C0 alone skipped the right branch without
advancing the tweakey over it, so the same key and message produced a different
C0 depending on whether C1 was also requested.

Round-trips 0/2 → 2/2 each. `PAEF-ForkSkinny-128-256` rose 2/3 → 3/3 as a
knock-on, with no change to its own file.

Two committed vectors were corrected. They had been transcribed faithfully from
the cited reference implementation, but from its left-only struct, which captures
an artefact of that path rather than the specified output; the replacements come
verbatim from the "Both Left" struct of the same file. This is the only change
here that alters a recorded expectation rather than code.

## Hierocrypt-3 — not fixable, exemption kept

The implementation in `hierocrypt3.js` is not invertible and cannot be made so.
Its S-box is not a bijection: the first step `b XOR ROTL8(b,1)` is singular over
GF(2) because `1+X` divides `X^8+1`, and later steps narrow it further, so all
256 byte values collapse onto 32 — an 8-to-1 map on every byte of every round.

Demonstrated rather than argued: under the committed key,
`00112233445566778899AABBCCDDEEFF` and `33112233445566778899AABBCCDDEEFF`
encrypt to the same ciphertext, which is the committed vector's own expected
value. The plaintext is unrecoverable in principle.

The genuine cipher is already present separately as `Hierocrypt-3 (DarkCrypt)`,
which round-trips 3/3. The exemption is deliberately retained and the file now
records why.

## Verification

- `TestSuite.js` 5574/5574, exit 0; no `Invertibility Requirement: ✗ FAILED` for
  the three fixed algorithms
- `RoundTripSuite.js` 608 passed, 0 failed, with the three exemptions removed so
  the suite enforces them from now on
- Randomised round-trips beyond the required cases: 200 per SKINNY key size,
  400 per ForkSkinny variant across left, right and combined modes
- README and browser script-tag checks clean

## Flagged, not addressed

`SKINNY-128` silently drops a trailing partial block on ragged input (17 in, 16
out) rather than refusing it, unlike ForkSkinny. Pre-existing and outside this
defect.
