### PR TITLE
LOTUS-AEAD, SATURNIN-Short, Fubuki and FF3 could not decrypt what they encrypted

### DIFF
--- a/Cipher/algorithms/aead/lotus-aead.js
+++ b/Cipher/algorithms/aead/lotus-aead.js
@@ -1,6 +1,8 @@
 /*
- * LOTUS-AEAD - Lightweight OCB-like AEAD Construction
- * Professional implementation following NIST LWC submission specification
+ * LOTUS-AEAD - Lightweight OTR-style AEAD Construction
+ * Follows the structure of the NIST LWC submission; see the note on the test
+ * vectors below, which records that this file does not yet reproduce the
+ * submission's own KAT and is therefore not interoperable with it.
  * (c)2006-2025 Hawkynt
  *
  * LOTUS-AEAD is a lightweight authenticated encryption with associated data (AEAD)
@@ -434,6 +436,148 @@
     return tag;
   }
 
+  // LOTUS-AEAD decryption.
+  //
+  // LOTUS-AEAD is an OTR-style (Offset Two-Round) mode over the short-tweak
+  // block cipher TweGIFT-64, described in "LOTUS-AEAD and LOCUS-AEAD", NIST
+  // Lightweight Cryptography submission, Section 3 (Specification of
+  // LOTUS-AEAD). Each plaintext pair (P0, P1) is processed by a two-round
+  // Feistel network whose round function is E applied twice under a fixed
+  // tweak, so the same network run backwards recovers the pair:
+  //
+  //   encryption            X1 = P0 ^ delta
+  //                         Z  = E^2_t4(X1) ^ P1        C0 = Z ^ delta
+  //                         C1 = X1 ^ E^2_t5(Z)
+  //
+  //   decryption            Z  = C0 ^ delta
+  //                         X1 = C1 ^ E^2_t5(Z)         P0 = X1 ^ delta
+  //                         P1 = Z ^ E^2_t4(X1)
+  //
+  // The checksum W absorbs the two single-encryption intermediates E_t4(X1)
+  // and E_t5(Z); XOR is commutative, so producing them in the reverse order
+  // during decryption yields the identical W and therefore the identical tag.
+  // The tag is recomputed here and returned to the caller for comparison; it
+  // is never derived from the received tag.
+  function lotusDecrypt(plaintext, ciphertext, ctlen, ad, adlen, key, nonce) {
+    const ks = new Gift64KeySchedule(key);
+    const WV = new Uint8Array(16); // W and V concatenated
+    const deltaN = new Uint8Array(GIFT64_BLOCK_SIZE);
+    const X1 = new Uint8Array(GIFT64_BLOCK_SIZE);
+    const X2 = new Uint8Array(GIFT64_BLOCK_SIZE);
+    const Z = new Uint8Array(GIFT64_BLOCK_SIZE);
+    const temp = new Uint8Array(16);
+
+    // Initialize
+    lotusInit(ks, deltaN, key, nonce, temp);
+    WV.fill(0);
+
+    const V = new Uint8Array(WV.buffer, GIFT64_BLOCK_SIZE, GIFT64_BLOCK_SIZE);
+    const W = new Uint8Array(WV.buffer, 0, GIFT64_BLOCK_SIZE);
+
+    // Process associated data - identical to encryption, the tag covers it the
+    // same way in both directions.
+    if (adlen > 0) {
+      lotusProcessAD(ks, deltaN, V, ad, adlen);
+    }
+
+    let mlen = ctlen;
+    let mpos = 0;
+    let cpos = 0;
+
+    if (mlen > 0) {
+      // Two-block chunks: invert the OTR Feistel network.
+      while (mlen > GIFT64_BLOCK_SIZE * 2) {
+        ks.mul2();
+        // Z = ciphertext[0:8] XOR deltaN
+        for (let i = 0; i < GIFT64_BLOCK_SIZE; ++i) {
+          Z[i] = OpCodes.XorN(ciphertext[cpos + i], deltaN[i]);
+        }
+        // W absorbs E_t5(Z), then X1 = ciphertext[8:16] XOR E^2_t5(Z)
+        gift64tEncrypt(ks, X2, Z, GIFT64_TWEAKS[5]);
+        for (let i = 0; i < GIFT64_BLOCK_SIZE; ++i) {
+          W[i] = OpCodes.XorN(W[i], X2[i]);
+        }
+        gift64tEncrypt(ks, X2, X2, GIFT64_TWEAKS[5]);
+        for (let i = 0; i < GIFT64_BLOCK_SIZE; ++i) {
+          X1[i] = OpCodes.XorN(ciphertext[cpos + GIFT64_BLOCK_SIZE + i], X2[i]);
+          plaintext[mpos + i] = OpCodes.XorN(X1[i], deltaN[i]);
+        }
+        // W absorbs E_t4(X1), then plaintext[8:16] = Z XOR E^2_t4(X1)
+        gift64tEncrypt(ks, X2, X1, GIFT64_TWEAKS[4]);
+        for (let i = 0; i < GIFT64_BLOCK_SIZE; ++i) {
+          W[i] = OpCodes.XorN(W[i], X2[i]);
+        }
+        gift64tEncrypt(ks, X2, X2, GIFT64_TWEAKS[4]);
+        for (let i = 0; i < GIFT64_BLOCK_SIZE; ++i) {
+          plaintext[mpos + GIFT64_BLOCK_SIZE + i] = OpCodes.XorN(Z[i], X2[i]);
+        }
+        cpos += GIFT64_BLOCK_SIZE * 2;
+        mpos += GIFT64_BLOCK_SIZE * 2;
+        mlen -= GIFT64_BLOCK_SIZE * 2;
+      }
+
+      // Final chunk. Its mask is derived from deltaN and the remaining length
+      // only, so it is reproduced exactly as the encryption side builds it.
+      ks.mul2();
+      for (let i = 0; i < GIFT64_BLOCK_SIZE; ++i) {
+        X1[i] = deltaN[i];
+      }
+      X1[0] = OpCodes.XorN(X1[0], OpCodes.AndN(mlen, 0xFFFFFFFF));
+      gift64tEncrypt(ks, X2, X1, GIFT64_TWEAKS[12]);
+      for (let i = 0; i < GIFT64_BLOCK_SIZE; ++i) {
+        W[i] = OpCodes.XorN(W[i], X2[i]);
+      }
+      gift64tEncrypt(ks, X2, X2, GIFT64_TWEAKS[12]);
+
+      if (mlen <= GIFT64_BLOCK_SIZE) {
+        // Single (possibly partial) block
+        for (let i = 0; i < mlen; ++i) {
+          const p = OpCodes.XorN(OpCodes.XorN(ciphertext[cpos + i], deltaN[i]), X2[i]);
+          plaintext[mpos + i] = p;
+          W[i] = OpCodes.XorN(W[i], p);
+          X2[i] = OpCodes.XorN(X2[i], p);
+        }
+      } else {
+        // Full block followed by a partial one
+        for (let i = 0; i < GIFT64_BLOCK_SIZE; ++i) {
+          const masked = OpCodes.XorN(ciphertext[cpos + i], deltaN[i]);
+          plaintext[mpos + i] = OpCodes.XorN(masked, X2[i]);
+          X2[i] = masked;
+        }
+        cpos += GIFT64_BLOCK_SIZE;
+        mpos += GIFT64_BLOCK_SIZE;
+        mlen -= GIFT64_BLOCK_SIZE;
+
+        gift64tEncrypt(ks, X2, X2, GIFT64_TWEAKS[13]);
+        for (let i = 0; i < GIFT64_BLOCK_SIZE; ++i) {
+          W[i] = OpCodes.XorN(W[i], X2[i]);
+        }
+        gift64tEncrypt(ks, X2, X2, GIFT64_TWEAKS[13]);
+        for (let i = 0; i < mlen; ++i) {
+          X1[i] = OpCodes.XorN(X1[i], X2[i]);
+          const p = OpCodes.XorN(ciphertext[cpos + i], X1[i]);
+          plaintext[mpos + i] = p;
+          W[i] = OpCodes.XorN(W[i], p);
+        }
+      }
+    }
+
+    // Recompute the tag over the recovered plaintext
+    const tag = new Uint8Array(GIFT64_BLOCK_SIZE);
+    lotusGenTag(ks, tag, deltaN, W, V);
+    return tag;
+  }
+
+  // Compare two tags without leaking the position of the first difference.
+  function lotusTagsMatch(expected, received) {
+    if (expected.length !== received.length) return false;
+    let diff = 0;
+    for (let i = 0; i < expected.length; ++i) {
+      diff = OpCodes.OrN(diff, OpCodes.XorN(expected[i], received[i]));
+    }
+    return diff === 0;
+  }
+
   // LOTUS-AEAD Algorithm class
   class LotusAeadAlgorithm extends AeadAlgorithm {
     constructor() {
@@ -479,10 +623,20 @@
         )
       ];
 
-      // Official test vectors from NIST LWC KAT file
+      // These are this implementation's own outputs, not the official ones,
+      // despite what they used to be labelled. LWC_AEAD_KAT_128_128.txt in the
+      // twegift64lotusaeadv1 directory of the LOTUS/LOCUS submission package
+      // linked below gives, for this key and nonce, 9E8DA381B9995459 (Count 1,
+      // no AD), AE25614ADBD7BD31 (Count 2, AD 00) and E61998A2B36DA347
+      // (Count 3, AD 0001). This file produces none of those, and matches 0 of
+      // the KAT's first 40 vectors, so the TweGIFT-64 core or the way LOTUS
+      // drives it departs from the specification somewhere. Decryption below is
+      // a true inverse of the encryption above and rejects forged tags, so the
+      // construction round-trips and authenticates; it is not interoperable
+      // with the reference until the core is reconciled with the KAT.
       this.tests = [
         {
-          text: "LOTUS-AEAD: Empty message, empty AAD (Count 1)",
+          text: "LOTUS-AEAD self-generated regression vector: empty message, empty AAD",
           uri: "https://csrc.nist.gov/projects/lightweight-cryptography",
           key: OpCodes.Hex8ToBytes("000102030405060708090A0B0C0D0E0F"),
           nonce: OpCodes.Hex8ToBytes("000102030405060708090A0B0C0D0E0F"),
@@ -491,7 +645,7 @@
           expected: OpCodes.Hex8ToBytes("37F3EBB83FF38DE8")
         },
         {
-          text: "LOTUS-AEAD: Empty message, 1-byte AAD (Count 2)",
+          text: "LOTUS-AEAD self-generated regression vector: empty message, 1-byte AAD",
           uri: "https://csrc.nist.gov/projects/lightweight-cryptography",
           key: OpCodes.Hex8ToBytes("000102030405060708090A0B0C0D0E0F"),
           nonce: OpCodes.Hex8ToBytes("000102030405060708090A0B0C0D0E0F"),
@@ -500,7 +654,7 @@
           expected: OpCodes.Hex8ToBytes("0020CF359FA6EC6E")
         },
         {
-          text: "LOTUS-AEAD: Empty message, 2-byte AAD (Count 3)",
+          text: "LOTUS-AEAD self-generated regression vector: empty message, 2-byte AAD",
           uri: "https://csrc.nist.gov/projects/lightweight-cryptography",
           key: OpCodes.Hex8ToBytes("000102030405060708090A0B0C0D0E0F"),
           nonce: OpCodes.Hex8ToBytes("000102030405060708090A0B0C0D0E0F"),
@@ -619,22 +773,15 @@
     Result() {
       if (!this._key) throw new Error("Key not set");
       if (!this._nonce) throw new Error("Nonce not set");
-      if (this.inputBuffer.length === 0) {
-        // Empty plaintext case - just generate tag
-        const aad = this._aad || new Uint8Array(0);
-        const tag = lotusEncrypt(
-          new Uint8Array(0),
-          new Uint8Array(0),
-          0,
-          aad,
-          aad.length,
-          this._key,
-          this._nonce
-        );
-        this.inputBuffer = [];
-        return Array.from(tag);
-      }
+      return this.isInverse ? this._decrypt() : this._encrypt();
+    }
 
+    /**
+   * Encrypt the buffered plaintext and append the 64-bit tag.
+   * @returns {uint8[]} ciphertext followed by the tag
+   */
+
+    _encrypt() {
       const plaintext = new Uint8Array(this.inputBuffer);
       const aad = this._aad || new Uint8Array(0);
       const ciphertext = new Uint8Array(plaintext.length);
@@ -656,6 +803,47 @@
 
       this.inputBuffer = [];
       return Array.from(result);
+    }
+
+    /**
+   * Split the tag off the buffered ciphertext, recover the plaintext and
+   * verify the tag. A mismatch is an authentication failure: it raises and
+   * yields no plaintext at all, rather than returning unverified bytes.
+   * @returns {uint8[]} recovered plaintext
+   * @throws {Error} if the input is shorter than a tag or the tag does not verify
+   */
+
+    _decrypt() {
+      const TAG_SIZE = GIFT64_BLOCK_SIZE;
+      if (this.inputBuffer.length < TAG_SIZE) {
+        this.inputBuffer = [];
+        throw new Error("Ciphertext too short: it must carry an 8-byte authentication tag");
+      }
+
+      const ctlen = this.inputBuffer.length - TAG_SIZE;
+      const ciphertext = new Uint8Array(this.inputBuffer.slice(0, ctlen));
+      const receivedTag = new Uint8Array(this.inputBuffer.slice(ctlen));
+      const aad = this._aad || new Uint8Array(0);
+      const plaintext = new Uint8Array(ctlen);
+
+      const expectedTag = lotusDecrypt(
+        plaintext,
+        ciphertext,
+        ctlen,
+        aad,
+        aad.length,
+        this._key,
+        this._nonce
+      );
+
+      this.inputBuffer = [];
+
+      if (!lotusTagsMatch(expectedTag, receivedTag)) {
+        plaintext.fill(0);
+        throw new Error("Authentication failed: LOTUS-AEAD tag mismatch");
+      }
+
+      return Array.from(plaintext);
     }
   }
 

--- a/Cipher/algorithms/aead/saturnin.js
+++ b/Cipher/algorithms/aead/saturnin.js
@@ -878,28 +878,42 @@ class SaturninShortInstance extends IAeadInstance {
     const decrypted = new Array(32);
     this.cipher.decryptBlock(decrypted, this.inputBuffer, SATURNIN_DOMAIN_10_6);
 
-    // Verify nonce (constant-time)
-    let check1 = 0;
+    // Saturnin-Short authenticates implicitly rather than with a separate tag:
+    // the specification (Saturnin submission, "Saturnin-Short") encrypts the
+    // single block N || M || 10* and decryption is one inverse block call
+    // followed by two checks - the recovered nonce must equal the one supplied,
+    // and the second half must be a message followed by 0x80 and then zeroes.
+    // Anything else is a forgery and must be refused.
+    //
+    // Both scans run to completion whatever they find, so the work done does
+    // not reveal where a difference lies. `failed` accumulates every reason to
+    // reject and is non-zero exactly when the block is not well formed.
+    let failed = 0;
+
+    // The first half must reproduce the nonce.
     for (let i = 0; i < 16; i++) {
-      check1 |= OpCodes.XorN(this._nonce[i], decrypted[i]);
+      failed = OpCodes.OrN(failed, OpCodes.XorN(this._nonce[i], decrypted[i]));
     }
 
-    // Find padding position and validate (constant-time)
-    let check2 = 0xFF;
+    // The second half must be M || 0x80 || 0*. Scanning downwards locates the
+    // last 0x80, which is the padding marker: `searching` stays 0xFF until the
+    // marker is met, and while it does every byte seen has to be zero.
+    let searching = 0xFF;
     let len = 0;
     for (let index = 15; index >= 0; index--) {
-      const temp = decrypted[16 + index];
-      const temp2 = OpCodes.AndN(check2, (-(1 - (OpCodes.Shr32(OpCodes.XorN(temp, 0x80) + 0xFF, 8)))));
-      len |= OpCodes.AndN(temp2, index);
-      check2 = OpCodes.ToUint32(OpCodes.AndN(check2, OpCodes.XorN(temp2, 0xFFFFFFFF)));
-      check1 |= OpCodes.AndN(check2, OpCodes.Shr32(temp + 0xFF, 8));
+      const octet = decrypted[16 + index];
+      // notMarker is 1 for any byte other than 0x80 and 0 for 0x80 itself, so
+      // notMarker - 1 is an all-ones mask exactly at the marker.
+      const notMarker = OpCodes.Shr32(OpCodes.XorN(octet, 0x80) + 0xFF, 8);
+      const isMarker = OpCodes.AndN(searching, notMarker - 1);
+      len = OpCodes.OrN(len, OpCodes.AndN(isMarker, index));
+      searching = OpCodes.AndN(searching, OpCodes.XorN(isMarker, 0xFF));
+      failed = OpCodes.OrN(failed, OpCodes.AndN(searching, OpCodes.Shr32(octet + 0xFF, 8)));
     }
-    check1 |= check2;
+    // Still searching once the scan is done means there was no 0x80 at all.
+    failed = OpCodes.OrN(failed, searching);
 
-    // check1 is 0 if valid, non-zero if invalid
-    const result = OpCodes.Shr32(check1 - 1, 8); // -1 if valid, 0 if invalid
-
-    if (OpCodes.ToUint32(OpCodes.XorN(result, 0xFFFFFFFF)) !== 0) {
+    if (failed !== 0) {
       throw new Error("Authentication failed: invalid nonce or padding");
     }
 

--- a/Cipher/algorithms/block/ff.js
+++ b/Cipher/algorithms/block/ff.js
@@ -70,8 +70,20 @@
     MIN_RADIX: 2,
     MAX_RADIX: 65536,
     TWEAK_LENGTH: 8, // FF3 requires 64-bit (8 byte) tweak
-    ROUNDS: 8
+    ROUNDS: 8,
+    MIN_DOMAIN_SIZE: 100 // radix^minlen >= 100 per NIST SP 800-38G Section 5.2
   };
+
+  // The lengths one radix admits, per NIST SP 800-38G Section 5.2 (FF3
+  // requirements): minlen is the smallest n with radix^n >= 100, and maxlen is
+  // 2 * floor(log_radix(2^96)). The old code hard-coded 2 and 56, which are the
+  // decimal answers, and applied them to every radix.
+  function ff3LengthLimits(radix) {
+    let minLength = 2;
+    while (Math.pow(radix, minLength) < FF3_CONSTANTS.MIN_DOMAIN_SIZE) minLength++;
+    const maxLength = 2 * Math.floor(96 * Math.LN2 / Math.log(radix));
+    return { minLength, maxLength };
+  }
 
   // ===== BIG INTEGER UTILITIES (SHARED) =====
 
@@ -842,10 +854,23 @@
         )
       ];
 
-      // Educational test vectors for FF3 demonstration (FF3 is deprecated)
+      // These vectors are produced by this file and are not NIST values, even
+      // though the key, tweak and plaintext look like a NIST sample. _aesEncrypt
+      // below is a linear congruential generator, not AES, and the round
+      // function omits the REV and REVB reversals SP 800-38G Algorithm 9
+      // prescribes, so no input can reproduce a published FF3 result. Checked
+      // against a conforming FF3 that does reproduce SP 800-38G Sample #1
+      // (key EF4359D8D580AA4F7F036D6F04FC6A94, tweak D8E7920AFA330A73,
+      // "890121234567890000" -> "750918814058654607"): with the key and tweak
+      // used here that same plaintext encrypts to "268059360717283457" and
+      // "123456789012345678" to "811138645228660102", neither of which is what
+      // this file produces. They are recorded as self-generated regression
+      // vectors so the behaviour is pinned, and the Feistel structure and the
+      // format-preserving encoding they exercise are genuine, but this
+      // algorithm is not interoperable with FF3 until it uses a real AES.
       this.tests = [
         {
-          text: "FF3 Sample - 18 digit decimal",
+          text: "FF3 self-generated regression vector - 18 decimal digits",
           uri: "https://nvlpubs.nist.gov/nistpubs/specialpublications/nist.sp.800-38g.pdf",
           input: OpCodes.AnsiToBytes("890121234567890000"),
           key: OpCodes.Hex8ToBytes("2DE79D232DF5585D68CE47882AE256D6"),
@@ -854,7 +879,7 @@
           expected: OpCodes.AnsiToBytes("616696145383400397")
         },
         {
-          text: "Educational FF3 Sample - round-trip verification",
+          text: "FF3 self-generated regression vector - round-trip verification",
           uri: "https://nvlpubs.nist.gov/nistpubs/specialpublications/nist.sp.800-38g.pdf",
           input: OpCodes.AnsiToBytes("123456789012345678"),
           key: OpCodes.Hex8ToBytes("2DE79D232DF5585D68CE47882AE256D6"),
@@ -972,7 +997,7 @@
 
       // For FF3, we expect string data that represents numerals
       if (typeof data === 'string') {
-        this.inputBuffer.push(...Array.from(data, char => char.charCodeAt(0)));
+        for (let _i = 0; _i < data.length; _i++) this.inputBuffer.push(data.charCodeAt(_i));
       } else {
         for (let _i = 0; _i < data.length; _i++) this.inputBuffer.push(data[_i]);
       }
@@ -988,34 +1013,30 @@
       if (!this.key) throw new Error("Key not set");
       if (this.inputBuffer.length === 0) throw new Error("No data fed");
 
-      // Convert buffer to string
-      const inputString = String.fromCharCode(...this.inputBuffer);
+      // Decode to numerals first: a byte that is not a symbol of this radix has
+      // no numeral and is rejected here rather than folded into range.
+      const X = this._bytesToNumerals(this.inputBuffer);
+      const n = X.length;
 
-      // Validate input length
-      if (inputString.length < FF3_CONSTANTS.MIN_LENGTH || inputString.length > FF3_CONSTANTS.MAX_LENGTH) {
-        throw new Error(`Input length must be between ${FF3_CONSTANTS.MIN_LENGTH} and ${FF3_CONSTANTS.MAX_LENGTH} characters`);
+      // Validate input length against what this radix actually admits
+      const { minLength, maxLength } = ff3LengthLimits(this._radix);
+      if (n < minLength || n > maxLength) {
+        throw new Error(`Input length ${n} is outside the ${minLength}..${maxLength} `
+          + `characters radix ${this._radix} admits`);
       }
 
-      // Process the string with FF3
-      const outputString = this.isInverse
-        ? this._decrypt(inputString)
-        : this._encrypt(inputString);
+      // Process the numerals with FF3
+      const Y = this.isInverse ? this._decrypt(X) : this._encrypt(X);
 
       // Clear input buffer
       this.inputBuffer = [];
 
-      return OpCodes.AnsiToBytes(outputString);
+      return this._numeralsToBytes(Y);
     }
 
     // FF3 encryption function (8 rounds)
-    _encrypt(plaintext) {
-      // Convert string to numerals based on radix
-      const X = this._stringToNumerals(plaintext);
+    _encrypt(X) {
       const n = X.length;
-
-      if (n < FF3_CONSTANTS.MIN_LENGTH || n > FF3_CONSTANTS.MAX_LENGTH) {
-        throw new Error(`FF3: Invalid plaintext length ${n}. Must be between ${FF3_CONSTANTS.MIN_LENGTH} and ${FF3_CONSTANTS.MAX_LENGTH}`);
-      }
 
       // Split into two halves (FF3 uses ceiling for first half)
       const u = Math.ceil(n / 2);
@@ -1072,13 +1093,11 @@
         [A, B] = [B, C];
       }
 
-      return this._numeralsToString([...A, ...B]);
+      return [...A, ...B];
     }
 
     // FF3 decryption function
-    _decrypt(ciphertext) {
-      // Convert string to numerals based on radix
-      const Y = this._stringToNumerals(ciphertext);
+    _decrypt(Y) {
       const n = Y.length;
 
       // Split into two halves
@@ -1130,12 +1149,16 @@
         [A, B] = [C, A];
       }
 
-      return this._numeralsToString([...A, ...B]);
+      return [...A, ...B];
     }
 
-    // Educational pseudo-random function for FF3 demonstration
-    // Calibrated to work with NIST test vectors for educational purposes
-    // NOTE: This is NOT real AES - FF3 is deprecated and this is for learning only
+    // Stand-in round function for FF3. This is a linear congruential generator
+    // seeded from the key and the block, not AES, so FF3 here reproduces no
+    // published test vector and offers no security whatsoever - the surrounding
+    // Feistel network is real but the primitive under it is not. Replacing it
+    // with the AES call SP 800-38G Algorithm 9 step 4c specifies, together with
+    // the REV/REVB reversals the same step requires, would make this algorithm
+    // interoperable; both of this file's FF3 vectors would then change.
     _aesEncrypt(plaintext) {
       if (!this._key || this._key.length === 0) {
         throw new Error("AES key not set for FF3 encryption");
@@ -1183,45 +1206,60 @@
       return state;
     }
 
-    // Convert string to numeral array
-    _stringToNumerals(str) {
+    // Decode input bytes to a numeral array.
+    //
+    // NIST SP 800-38G Section 4 requires the character-to-numeral map to be a
+    // bijection onto {0..radix-1}: only then does STR^m_radix invert NUM_radix
+    // and the cipher preserve its own format. The map used here previously sent
+    // both 'A' and 'a' to 10 while the inverse emitted only lowercase, so for
+    // any radix above 10 an upper-case message came back lower-cased -
+    // "ABCDEFGHIJKLMNOP" decrypted to "abcdefghijklmnop". The 62-symbol map
+    // below is injective, matching the one FF1 in this same file already uses,
+    // and a byte outside it is refused rather than folded into range.
+    _bytesToNumerals(bytes) {
       const numerals = [];
-      for (let i = 0; i < str.length; i++) {
-        const char = str[i];
+      for (let i = 0; i < bytes.length; i++) {
+        const byte = bytes[i];
         let numeral;
 
-        if (char >= '0' && char <= '9') {
-          numeral = char.charCodeAt(0) - 48;
-        } else if (char >= 'a' && char <= 'z') {
-          numeral = char.charCodeAt(0) - 87;
-        } else if (char >= 'A' && char <= 'Z') {
-          numeral = char.charCodeAt(0) - 55;
+        if (byte >= 48 && byte <= 57) {
+          numeral = byte - 48;        // '0'-'9' -> 0..9
+        } else if (byte >= 97 && byte <= 122) {
+          numeral = byte - 97 + 10;   // 'a'-'z' -> 10..35
+        } else if (byte >= 65 && byte <= 90) {
+          numeral = byte - 65 + 36;   // 'A'-'Z' -> 36..61
         } else {
-          throw new Error('FF3: Invalid character in input string');
+          throw new Error(`FF3: byte 0x${byte.toString(16)} is not a symbol of radix ${this._radix}`);
         }
 
         if (numeral >= this._radix) {
-          throw new Error('FF3: Character not valid for specified radix');
+          throw new Error(`FF3: symbol value ${numeral} is not valid for radix ${this._radix}`);
         }
         numerals.push(numeral);
       }
       return numerals;
     }
 
-    // Convert numeral array to string
-    _numeralsToString(numerals) {
-      let result = '';
+    // Encode a numeral array back to bytes, inverting _bytesToNumerals exactly.
+    _numeralsToBytes(numerals) {
+      const bytes = new Uint8Array(numerals.length);
       for (let i = 0; i < numerals.length; i++) {
         const numeral = numerals[i];
+        if (numeral >= this._radix) {
+          throw new Error(`FF3: numeral ${numeral} is not valid for radix ${this._radix}`);
+        }
+
         if (numeral < 10) {
-          result += String.fromCharCode(48 + numeral);
+          bytes[i] = numeral + 48;
         } else if (numeral < 36) {
-          result += String.fromCharCode(87 + numeral);
+          bytes[i] = numeral - 10 + 97;
+        } else if (numeral < 62) {
+          bytes[i] = numeral - 36 + 65;
         } else {
-          throw new Error('FF3: Invalid numeral value');
+          throw new Error(`FF3: radix ${this._radix} needs more than the 62 symbols this encoding carries`);
         }
       }
-      return result;
+      return bytes;
     }
 
     // Convert numeral array to big integer (using string arithmetic for precision)

--- a/Cipher/algorithms/stream/darkcrypt-fubuki.js
+++ b/Cipher/algorithms/stream/darkcrypt-fubuki.js
@@ -38,6 +38,14 @@
  * (it is explicitly designed to double as a block cipher); running it over
  * an all-zero buffer reproduces the keystream in the ordinary sense, which
  * is how the test vectors below were captured.
+ *
+ * That also fixes the domain: Section 1 of the published description states
+ * that "a plain message is a finite sequence of blocks, i.e. an element of
+ * B^L", and Definition 1.1 gives the encoding and decoding functions as
+ * bijections between whole blocks. A message length that is not a multiple of
+ * sixteen bytes is therefore outside the cipher and is refused rather than
+ * padded, because no padding of a short tail survives being cut back to the
+ * original length.
  */
 
 (function (root, factory) {
@@ -643,25 +651,42 @@
       if (this.jump === 0) this.jump = OpCodes.Shr32(TUPLE, 1);
     }
 
+    // Fubuki's domain is whole blocks and nothing else. Section 1 of the
+    // published description fixes it: "A plain message is a finite sequence of
+    // blocks, i.e. an element of B^L", with B = W^4, four 32-bit words, and
+    // Definition 1.1 gives the encoding and decoding functions as bijections
+    // E_i, D_i : B -> B. There is no partial-block rule anywhere in the design,
+    // and there cannot be a length-preserving one: each block is transformed as
+    // a unit, so the sixteen ciphertext bytes are all needed to invert it.
+    //
+    // Zero-padding a short tail and then cutting the ciphertext back to the
+    // input length threw away exactly the bytes the inverse needs, which is why
+    // any input that was not a block multiple encrypted happily and then came
+    // back as noise. A length outside the domain is refused here instead.
     _process(bytesIn, isInverse) {
       const blockBytes = 4 * TUPLE;
-      const repeat = Math.ceil(bytesIn.length / blockBytes);
+      if (bytesIn.length % blockBytes !== 0)
+        throw new Error(`Fubuki (DarkCrypt) encodes whole ${blockBytes}-byte blocks; `
+          + `${bytesIn.length} bytes is not a multiple of ${blockBytes}`);
+
+      const repeat = bytesIn.length / blockBytes;
       const out = [];
       let pos = 0;
       for (let r = 0; r < repeat; r++) {
         const block = new Uint32Array(TUPLE);
-        for (let i = 0; i < TUPLE; i++) {
-          const b0 = bytesIn[pos + i * 4] || 0;
-          const b1 = bytesIn[pos + i * 4 + 1] || 0;
-          const b2 = bytesIn[pos + i * 4 + 2] || 0;
-          const b3 = bytesIn[pos + i * 4 + 3] || 0;
-          block[i] = OpCodes.Pack32LE(b0, b1, b2, b3);
-        }
+        for (let i = 0; i < TUPLE; i++)
+          block[i] = OpCodes.Pack32LE(bytesIn[pos + i * 4], bytesIn[pos + i * 4 + 1],
+                                      bytesIn[pos + i * 4 + 2], bytesIn[pos + i * 4 + 3]);
+
         if (isInverse) this._decryptBlock(block); else this._encryptBlock(block);
-        for (let i = 0; i < TUPLE; i++) out.push(...OpCodes.Unpack32LE(block[i]));
+
+        for (let i = 0; i < TUPLE; i++) {
+          const bytes = OpCodes.Unpack32LE(block[i]);
+          out.push(bytes[0], bytes[1], bytes[2], bytes[3]);
+        }
         pos += blockBytes;
       }
-      return out.slice(0, bytesIn.length);
+      return out;
     }
   }
 

--- a/Cipher/tests/RoundTripSuite.js
+++ b/Cipher/tests/RoundTripSuite.js
@@ -453,7 +453,6 @@ const ROUND_TRIP_EXEMPT = new Map([
   ['SC2000', 'open defect: decryption does not invert encryption (TestSuite reports 0/1)'],
   ['SKINNY-128', 'open defect: decryption does not invert encryption (TestSuite reports 0/2)'],
   ['SPEED', 'open defect: decryption does not invert encryption (TestSuite reports 0/1)'],
-  ['SATURNIN-Short', 'open defect: decryption does not invert encryption (TestSuite reports 0/1)'],
   // Found by this sweep rather than by the vectors, and left recorded rather
   // than silently dropped, because each needs work beyond a decryption fix.
   ['HPC', 'open defect: variable-length block handling does not round-trip away from the vector'],

--- a/Cipher/tests/RoundTripSuite.js
+++ b/Cipher/tests/RoundTripSuite.js
@@ -453,7 +453,6 @@ const ROUND_TRIP_EXEMPT = new Map([
   ['SC2000', 'open defect: decryption does not invert encryption (TestSuite reports 0/1)'],
   ['SKINNY-128', 'open defect: decryption does not invert encryption (TestSuite reports 0/2)'],
   ['SPEED', 'open defect: decryption does not invert encryption (TestSuite reports 0/1)'],
-  ['LOTUS-AEAD', 'open defect: decryption does not invert encryption (TestSuite reports 0/3)'],
   ['SATURNIN-Short', 'open defect: decryption does not invert encryption (TestSuite reports 0/1)'],
   // Found by this sweep rather than by the vectors, and left recorded rather
   // than silently dropped, because each needs work beyond a decryption fix.

--- a/Cipher/tests/RoundTripSuite.js
+++ b/Cipher/tests/RoundTripSuite.js
@@ -456,7 +456,6 @@ const ROUND_TRIP_EXEMPT = new Map([
   // Found by this sweep rather than by the vectors, and left recorded rather
   // than silently dropped, because each needs work beyond a decryption fix.
   ['HPC', 'open defect: variable-length block handling does not round-trip away from the vector'],
-  ['Fubuki (DarkCrypt)', 'open defect: does not round-trip on input longer than one keystream block'],
   ['FF3', 'open defect: accepts none of the lengths its own radix admits'],
 ]);
 

--- a/Cipher/tests/RoundTripSuite.js
+++ b/Cipher/tests/RoundTripSuite.js
@@ -456,7 +456,6 @@ const ROUND_TRIP_EXEMPT = new Map([
   // Found by this sweep rather than by the vectors, and left recorded rather
   // than silently dropped, because each needs work beyond a decryption fix.
   ['HPC', 'open defect: variable-length block handling does not round-trip away from the vector'],
-  ['FF3', 'open defect: accepts none of the lengths its own radix admits'],
 ]);
 
 /**


### PR DESCRIPTION
Four algorithms whose decryption path had never worked, plus two provenance
claims that turned out to be false.

## LOTUS-AEAD

`Result()` never read `this.isInverse`, and there was no decryption function in
the file at all — "decrypting" ran the encryptor over ciphertext-plus-tag and
appended a *second* tag, taking 16 bytes to 24 to 32. The same shape MORUS had.

Added the OTR two-round Feistel run backwards. The checksum absorbs the same two
intermediates in the opposite order, which XOR makes irrelevant, so the tag is
unchanged. The tag is recomputed and compared in constant time; a mismatch zeroes
the buffer and throws.

Round-trips 0/3 → 3/3, plus 60 lengths from 1 to 257 across four fills and a
9×10 associated-data by plaintext-length matrix. Every single-bit flip across all
25 ciphertext and tag bytes is rejected, as are truncation and a modified AAD.

**Its vectors did not come from where they said.** They claimed "Official test
vectors from NIST LWC KAT file", but this implementation reproduces 0 of 40
vectors in `LWC_AEAD_KAT_128_128.txt`; the real KAT gives different values for
those exact inputs. The TweGIFT-64 core departs from the specification somewhere.
The bytes are unchanged and the vectors are now labelled self-generated:
invertibility is proven, interoperability is not.

## SATURNIN-Short

Not the block cipher — `decryptBlock` was already an exact inverse of
`encryptBlock` across all 8 domains. The defect was the final gate:
`OpCodes.Shr32(check1 - 1, 8)` is a *logical* shift where the idiom needs an
arithmetic one. For a valid block it yielded `0x00FFFFFF` instead of
`0xFFFFFFFF`, so the guard was non-zero and **every** decryption threw.

Round-trips 0/1 → 1/1, plus all 16 message lengths across four fills and messages
whose last byte is the `0x80` padding marker.

Rejection was not weakened to achieve this: the new predicate was
differential-tested against the old one over 400,000 blocks — 200,000 well-formed
and 200,000 forgeries — and the accept/reject decision and recovered length agree
on every one.

## Fubuki

`_process` zero-padded a partial final block, encoded it, then truncated the
ciphertext back to the input length, discarding exactly the bytes the inverse
needs. Whole-block lengths always worked at any size, so the recorded symptom
("fails beyond one keystream block") was imprecise.

Fubuki is defined over whole blocks — the eSTREAM description gives encryption
and decryption as bijections on `B^L` with no partial-block rule — so partial
input is now refused rather than silently corrupted. Two failing suite cases → 0,
plus 37 whole-block lengths from 16 to 4096 bytes and nine partial lengths
correctly refused.

## FF3

The recorded symptom was stale: FF3 already round-tripped every decimal length
before any change. But the defect the brief pointed at was real — the
character-to-numeral map was **not injective**. `'A'` and `'a'` both mapped to 10
while the inverse emitted only lowercase, so at radix 36
`"ABCDEFGHIJKLMNOP"` decrypted to `"abcdefghijklmnop"`. The same class of defect
as FPE and FFX.

Now uses the injective 62-symbol map FF1 already has in the same file, refuses
out-of-radix symbols, and derives length limits from the radix per SP 800-38G
§5.2 instead of the hard-coded decimal answers.

**This is a stub, not an implementation.** `_aesEncrypt` is a linear congruential
generator seeded from a 32-bit hash — the file's own comment said "This is NOT
real AES" while a nearby comment claimed the vectors were "calibrated for NIST
test vectors". A conforming FF3 written for comparison reproduces SP 800-38G
Sample #1 and Sample #2 exactly, and on this repo's own key and tweak produces
values matching neither committed vector. The bytes are unchanged, both vectors
are relabelled self-generated, and the misleading comment is replaced with what
the function actually is.

## Verification

- `TestSuite.js` 5574/5574, exit 0
- `RoundTripSuite.js` 612 passed, 0 failed, with all four exemptions removed so
  the suite enforces them from now on
- FF3 refuses punctuation at radix 10 rather than folding it
