### PR TITLE
Eight classical ciphers silently discarded input instead of handling or refusing it

### DIFF
--- a/Cipher/algorithms/classical/affine.js
+++ b/Cipher/algorithms/classical/affine.js
@@ -46,6 +46,19 @@
           IKdfInstance, IAeadInstance, IErrorCorrectionInstance, IRandomGeneratorInstance,
           TestCase, LinkItem, Vulnerability, AuthResult, KeySize } = AlgorithmFramework;
 
+  const UPPER_A = 65, UPPER_Z = 90, LOWER_A = 97, LOWER_Z = 122;
+
+  /**
+   * Alphabet origin of a byte: 65 for A-Z, 97 for a-z, -1 for anything else.
+   * @param {number} byte - Input byte
+   * @returns {number} Character code of the letter's own 'A', or -1
+   */
+  function LetterCaseBase(byte) {
+    if (byte >= UPPER_A && byte <= UPPER_Z) return UPPER_A;
+    if (byte >= LOWER_A && byte <= LOWER_Z) return LOWER_A;
+    return -1;
+  }
+
   // ===== ALGORITHM IMPLEMENTATION =====
 
   class AffineCipher extends CryptoAlgorithm {
@@ -54,7 +67,7 @@
 
       // Required metadata
       this.name = "Affine Cipher";
-      this.description = "Classical mathematical cipher using linear transformation f(x) = (ax + b) mod 26. Requires coefficient 'a' to be coprime with 26 for reversibility. One of the oldest mathematical ciphers based on modular arithmetic.";
+      this.description = "Classical mathematical cipher using linear transformation f(x) = (ax + b) mod 26. Requires coefficient 'a' to be coprime with 26 for reversibility. One of the oldest mathematical ciphers based on modular arithmetic. Input domain: every byte is accepted. A-Z and a-z are enciphered in place with their case preserved; every other byte - digit, punctuation, whitespace, control or high-bit - is carried through unchanged, which is the usual pen-and-paper convention and makes the round trip exact for arbitrary input. Nothing is ever discarded.";
       this.inventor = "Unknown (Ancient)";
       this.year = 1929;
       this.category = CategoryType.CLASSICAL;
@@ -231,28 +244,28 @@
         return [];
       }
 
-      const output = [];
-      const inputStr = String.fromCharCode.apply(null, this.inputBuffer);
+      const output = new Array(this.inputBuffer.length);
+      const aInverse = this.isInverse ? this.modInverse(this.keyA, 26) : 0;
 
-      // Normalize input to uppercase letters only
-      const normalizedInput = inputStr.toUpperCase().replace(/[^A-Z]/g, '');
+      // Every byte is accounted for. A letter is enciphered in its own case;
+      // anything else is copied through untouched. The earlier "uppercase and
+      // strip everything but A-Z" normalisation silently shortened the
+      // message - five binary bytes came back as none.
+      for (let i = 0; i < this.inputBuffer.length; i++) {
+        const byte = this.inputBuffer[i];
+        const caseBase = LetterCaseBase(byte);
 
-      // Process each character
-      for (const char of normalizedInput) {
-        const x = char.charCodeAt(0) - 65; // Convert A-Z to 0-25
-        let y;
-
-        if (this.isInverse) {
-          // Decryption: x = a^-1 * (y - b) mod 26
-          const aInv = this.modInverse(this.keyA, 26);
-          y = (aInv * (x - this.keyB + 26)) % 26;
-        } else {
-          // Encryption: y = (ax + b) mod 26
-          y = (this.keyA * x + this.keyB) % 26;
+        if (caseBase < 0) {
+          output[i] = byte;
+          continue;
         }
 
-        const resultChar = String.fromCharCode(y + 65); // Convert 0-25 back to A-Z
-        output.push(resultChar.charCodeAt(0));
+        const x = byte - caseBase; // Convert the letter to 0-25 within its own case
+        const y = this.isInverse
+          ? (aInverse * (x - this.keyB + 26)) % 26   // Decryption: x = a^-1 * (y - b) mod 26
+          : (this.keyA * x + this.keyB) % 26;        // Encryption: y = (ax + b) mod 26
+
+        output[i] = caseBase + y;
       }
 
       // Clear input buffer for next operation

--- a/Cipher/algorithms/classical/autokey.js
+++ b/Cipher/algorithms/classical/autokey.js
@@ -46,6 +46,19 @@
           IKdfInstance, IAeadInstance, IErrorCorrectionInstance, IRandomGeneratorInstance,
           TestCase, LinkItem, Vulnerability, AuthResult, KeySize } = AlgorithmFramework;
 
+  const UPPER_A = 65, UPPER_Z = 90, LOWER_A = 97, LOWER_Z = 122;
+
+  /**
+   * Alphabet origin of a byte: 65 for A-Z, 97 for a-z, -1 for anything else.
+   * @param {number} byte - Input byte
+   * @returns {number} Character code of the letter's own 'A', or -1
+   */
+  function LetterCaseBase(byte) {
+    if (byte >= UPPER_A && byte <= UPPER_Z) return UPPER_A;
+    if (byte >= LOWER_A && byte <= LOWER_Z) return LOWER_A;
+    return -1;
+  }
+
   // ===== ALGORITHM IMPLEMENTATION =====
 
   class AutokeyCipher extends CryptoAlgorithm {
@@ -54,7 +67,7 @@
 
       // Required metadata
       this.name = "Autokey Cipher";
-      this.description = "Enhanced Vigenère cipher that extends the key using plaintext itself, eliminating periodic key repetition. Uses initial keyword plus plaintext letters to create non-repeating key sequence. More secure than standard Vigenère.";
+      this.description = "Enhanced Vigenère cipher that extends the key using plaintext itself, eliminating periodic key repetition. Uses initial keyword plus plaintext letters to create non-repeating key sequence. More secure than standard Vigenère. Input domain: every byte is accepted. A-Z and a-z are enciphered in place with their case preserved and are the only bytes that extend the running key, which uses their uppercase form; every other byte - digit, punctuation, whitespace, control or high-bit - is carried through unchanged and takes no part in the key, which is the usual pen-and-paper convention and makes the round trip exact for arbitrary input. Nothing is ever discarded.";
       this.inventor = "Blaise de Vigenère";
       this.year = 1586;
       this.category = CategoryType.CLASSICAL;
@@ -205,52 +218,46 @@
         return [];
       }
 
-      const output = [];
+      const output = new Array(this.inputBuffer.length);
       const initialKey = this.key;
-      const inputStr = String.fromCharCode.apply(null, this.inputBuffer);
 
-      // Normalize input to uppercase letters only
-      const normalizedInput = inputStr.toUpperCase().replace(/[^A-Z]/g, '');
+      // Every byte is accounted for. A letter is enciphered in its own case
+      // and both consumes and extends the running key; anything else is copied
+      // through untouched and takes no part in the key at all. The earlier
+      // "uppercase and strip everything but A-Z" normalisation silently
+      // shortened the message - five binary bytes came back as none.
+      //
+      // The running key is the keyword followed by the plaintext letters in
+      // uppercase, and it is grown one letter at a time in both directions:
+      // encryption knows the plaintext outright, decryption recovers it as it
+      // goes. Since the keyword is never empty the key always holds at least
+      // one more letter than has been consumed.
+      let runningKey = initialKey;
+      let letterIndex = 0;
 
-      if (this.isInverse) {
-        // Decryption: build key as we decrypt
-        let extendedKey = initialKey;
+      for (let i = 0; i < this.inputBuffer.length; i++) {
+        const byte = this.inputBuffer[i];
+        const caseBase = LetterCaseBase(byte);
 
-        for (let i = 0; i < normalizedInput.length; i++) {
-          const cipherChar = normalizedInput[i];
-          const keyChar = extendedKey[i % extendedKey.length];
-
-          const cipherIndex = this.ALPHABET.indexOf(cipherChar);
-          const keyIndex = this.ALPHABET.indexOf(keyChar);
-
-          // Decrypt: (cipher - key + 26) mod 26
-          const plainIndex = (cipherIndex - keyIndex + 26) % 26;
-          const plainChar = this.ALPHABET[plainIndex];
-
-          // Extend key with decrypted plaintext character
-          if (extendedKey.length <= i + initialKey.length) {
-            extendedKey += plainChar;
-          }
-
-          output.push(plainChar.charCodeAt(0));
+        if (caseBase < 0) {
+          output[i] = byte;
+          continue;
         }
-      } else {
-        // Encryption: extend key with plaintext
-        let extendedKey = initialKey + normalizedInput;
 
-        for (let i = 0; i < normalizedInput.length; i++) {
-          const textChar = normalizedInput[i];
-          const keyChar = extendedKey[i];
+        const textIndex = byte - caseBase;
+        const keyIndex = this.ALPHABET.indexOf(runningKey[letterIndex]);
+        ++letterIndex;
 
-          const textIndex = this.ALPHABET.indexOf(textChar);
-          const keyIndex = this.ALPHABET.indexOf(keyChar);
+        // Encrypt: (text + key) mod 26; decrypt: (cipher - key + 26) mod 26
+        const resultIndex = this.isInverse
+          ? (textIndex - keyIndex + 26) % 26
+          : (textIndex + keyIndex) % 26;
 
-          // Encrypt: (text + key) mod 26
-          const cipherIndex = (textIndex + keyIndex) % 26;
-          const cipherChar = this.ALPHABET[cipherIndex];
+        // The key is always extended with the PLAINTEXT letter, which is the
+        // input when encrypting and the result when decrypting.
+        runningKey += this.ALPHABET[this.isInverse ? resultIndex : textIndex];
 
-          output.push(cipherChar.charCodeAt(0));
-        }
+        output[i] = caseBase + resultIndex;
       }
 
       // Clear input buffer for next operation

--- a/Cipher/algorithms/classical/autokey.js
+++ b/Cipher/algorithms/classical/autokey.js
@@ -227,12 +227,19 @@
       // "uppercase and strip everything but A-Z" normalisation silently
       // shortened the message - five binary bytes came back as none.
       //
-      // The running key is the keyword followed by the plaintext letters in
-      // uppercase, and it is grown one letter at a time in both directions:
-      // encryption knows the plaintext outright, decryption recovers it as it
-      // goes. Since the keyword is never empty the key always holds at least
-      // one more letter than has been consumed.
-      let runningKey = initialKey;
+      // The running key is the keyword followed by the plaintext letters, held
+      // as alphabet positions and grown one letter at a time in both
+      // directions: encryption knows the plaintext outright, decryption
+      // recovers it as it goes. Since the keyword is never empty the key
+      // always holds at least one more letter than has been consumed.
+      //
+      // Positions rather than a string, because appending to a string and then
+      // indexing it forces V8 to flatten the rope on every letter, which is
+      // quadratic: a megabyte of text took two and a half minutes that way.
+      const runningKey = new Array(initialKey.length);
+      for (let k = 0; k < initialKey.length; k++)
+        runningKey[k] = this.ALPHABET.indexOf(initialKey[k]);
+
       let letterIndex = 0;
 
       for (let i = 0; i < this.inputBuffer.length; i++) {
@@ -245,7 +252,7 @@
         }
 
         const textIndex = byte - caseBase;
-        const keyIndex = this.ALPHABET.indexOf(runningKey[letterIndex]);
+        const keyIndex = runningKey[letterIndex];
         ++letterIndex;
 
         // Encrypt: (text + key) mod 26; decrypt: (cipher - key + 26) mod 26
@@ -255,7 +262,7 @@
 
         // The key is always extended with the PLAINTEXT letter, which is the
         // input when encrypting and the result when decrypting.
-        runningKey += this.ALPHABET[this.isInverse ? resultIndex : textIndex];
+        runningKey.push(this.isInverse ? resultIndex : textIndex);
 
         output[i] = caseBase + resultIndex;
       }

--- a/Cipher/algorithms/classical/beaufort.js
+++ b/Cipher/algorithms/classical/beaufort.js
@@ -46,6 +46,19 @@
           IKdfInstance, IAeadInstance, IErrorCorrectionInstance, IRandomGeneratorInstance,
           TestCase, LinkItem, Vulnerability, AuthResult, KeySize } = AlgorithmFramework;
 
+  const UPPER_A = 65, UPPER_Z = 90, LOWER_A = 97, LOWER_Z = 122;
+
+  /**
+   * Alphabet origin of a byte: 65 for A-Z, 97 for a-z, -1 for anything else.
+   * @param {number} byte - Input byte
+   * @returns {number} Character code of the letter's own 'A', or -1
+   */
+  function LetterCaseBase(byte) {
+    if (byte >= UPPER_A && byte <= UPPER_Z) return UPPER_A;
+    if (byte >= LOWER_A && byte <= LOWER_Z) return LOWER_A;
+    return -1;
+  }
+
   // ===== ALGORITHM IMPLEMENTATION =====
 
   class BeaufortCipher extends CryptoAlgorithm {
@@ -54,7 +67,7 @@
 
       // Required metadata
       this.name = "Beaufort Cipher";
-      this.description = "Reciprocal polyalphabetic substitution cipher invented by Sir Francis Beaufort. Uses formula C = (K - P) mod 26 where encryption and decryption are identical operations. Variant of Vigenère cipher with reciprocal property.";
+      this.description = "Reciprocal polyalphabetic substitution cipher invented by Sir Francis Beaufort. Uses formula C = (K - P) mod 26 where encryption and decryption are identical operations. Variant of Vigenère cipher with reciprocal property. Input domain: every byte is accepted. A-Z and a-z are enciphered in place with their case preserved and advance the keyword; every other byte - digit, punctuation, whitespace, control or high-bit - is carried through unchanged and leaves the keyword position alone, which is the usual pen-and-paper convention and makes the round trip exact for arbitrary input. Nothing is ever discarded.";
       this.inventor = "Sir Francis Beaufort";
       this.year = 1857;
       this.category = CategoryType.CLASSICAL;
@@ -204,27 +217,30 @@
         return [];
       }
 
-      const output = [];
+      const output = new Array(this.inputBuffer.length);
       const processedKey = this.key;
-      const inputStr = String.fromCharCode.apply(null, this.inputBuffer);
 
-      // Normalize input to uppercase letters only
-      const normalizedInput = inputStr.toUpperCase().replace(/[^A-Z]/g, '');
+      // Every byte is accounted for. A letter is enciphered in its own case
+      // and consumes one keyword position; anything else is copied through
+      // untouched and does not move the keyword on. The earlier "uppercase
+      // and strip everything but A-Z" normalisation silently shortened the
+      // message - five binary bytes came back as none.
+      let keyPosition = 0;
+      for (let i = 0; i < this.inputBuffer.length; i++) {
+        const byte = this.inputBuffer[i];
+        const caseBase = LetterCaseBase(byte);
 
-      // Process each character (Beaufort is reciprocal, so encryption=decryption)
-      for (let i = 0; i < normalizedInput.length; i++) {
-        const textChar = normalizedInput[i];
-        const keyChar = processedKey[i % processedKey.length];
-
-        const textIndex = this.ALPHABET.indexOf(textChar);
-        const keyIndex = this.ALPHABET.indexOf(keyChar);
-
-        if (textIndex !== -1 && keyIndex !== -1) {
-          // Beaufort formula: C = (K - P + 26) mod 26
-          const resultIndex = (keyIndex - textIndex + 26) % 26;
-          const resultChar = this.ALPHABET[resultIndex];
-          output.push(resultChar.charCodeAt(0));
+        if (caseBase < 0) {
+          output[i] = byte;
+          continue;
         }
+
+        const textIndex = byte - caseBase;
+        const keyIndex = this.ALPHABET.indexOf(processedKey[keyPosition % processedKey.length]);
+        ++keyPosition;
+
+        // Beaufort formula: C = (K - P + 26) mod 26, and it is its own inverse
+        output[i] = caseBase + ((keyIndex - textIndex + 26) % 26);
       }
 
       // Clear input buffer for next operation

--- a/Cipher/algorithms/classical/columnar.js
+++ b/Cipher/algorithms/classical/columnar.js
@@ -243,6 +243,9 @@
        * @returns {uint8[]} Transposed bytes
        */
       EncryptBlock(blockIndex, plaintext) {
+        // With no keyword there are no columns to read, so the message stands
+        if (!this._cleanKey || this._cleanKey.length === 0) return plaintext;
+
         const columns = this._cleanKey.length;
         const rows = Math.ceil(plaintext.length / columns);
         const result = new Array(rows * columns);
@@ -269,6 +272,9 @@
        * @returns {uint8[]} Original bytes, less any trailing X
        */
       DecryptBlock(blockIndex, ciphertext) {
+        // With no keyword there are no columns to refill, so the message stands
+        if (!this._cleanKey || this._cleanKey.length === 0) return ciphertext;
+
         const columns = this._cleanKey.length;
         const rows = Math.ceil(ciphertext.length / columns);
         const baseHeight = Math.floor(ciphertext.length / columns);
@@ -320,9 +326,6 @@
         // message encrypted to nothing and decrypted back to nothing with no
         // error raised.
         RequireLetters(message);
-
-        // With no keyword there are no columns to read, so the message stands
-        if (!this._cleanKey || this._cleanKey.length === 0) return message;
 
         return this.isInverse
           ? this.DecryptBlock(0, message)

--- a/Cipher/algorithms/classical/columnar.js
+++ b/Cipher/algorithms/classical/columnar.js
@@ -46,13 +46,42 @@
           IKdfInstance, IAeadInstance, IErrorCorrectionInstance, IRandomGeneratorInstance,
           TestCase, LinkItem, Vulnerability, AuthResult, KeySize } = AlgorithmFramework;
 
+  const UPPER_A = 65, UPPER_Z = 90;
+
+  // The letter the final row of the grid is filled out with, and the letter
+  // stripped from the end again on the way back.
+  const PAD_LETTER = 88; // 'X'
+
+  /**
+   * Printable stand-in for a byte, for use in an error message.
+   * @param {number} byte - Offending byte
+   * @returns {string} The character itself when it is printable ASCII, else '?'
+   */
+  function DescribeByte(byte) {
+    return byte >= 0x20 && byte <= 0x7e ? String.fromCharCode(byte) : '?';
+  }
+
+  /**
+   * Reject the first byte the cipher has no cell for, naming it and its place.
+   * @param {uint8[]} message - Bytes about to be transposed
+   * @throws {Error} On the first byte outside A-Z
+   */
+  function RequireLetters(message) {
+    for (let i = 0; i < message.length; i++) {
+      const byte = message[i];
+      if (byte < UPPER_A || byte > UPPER_Z)
+        throw new Error(`ColumnarInstance.Result: byte 0x${byte.toString(16).padStart(2, '0')}`
+          + ` ('${DescribeByte(byte)}') at position ${i} is outside the A-Z alphabet the grid holds`);
+    }
+  }
+
   // ===== ALGORITHM IMPLEMENTATION =====
 
   class ColumnarCipher extends CryptoAlgorithm {
       constructor() {
         super();
         this.name = 'Columnar Transposition';
-        this.description = 'Classical transposition cipher that arranges plaintext in a grid and reads columns in keyword-alphabetical order.';
+        this.description = 'Classical transposition cipher that arranges plaintext in a grid and reads columns in keyword-alphabetical order. Input domain: uppercase A-Z only. This is the complete form of the cipher, in which the final row of the grid is filled out with the letter X before the columns are read, so the alphabet has to be the one the padding letter belongs to and anything else is refused by name and position rather than dropped. Decryption removes trailing X again, which means a message that genuinely ends in X comes back short - the same ambiguity as zero padding, and the one thing here that is not an exact round trip.';
         this.category = CategoryType.CLASSICAL;
         this.securityStatus = SecurityStatus.EDUCATIONAL;
         this.complexity = ComplexityType.INTERMEDIATE;
@@ -62,6 +91,12 @@
 
         this.keySize = { min: 1, max: 50, step: 1 };
         this.blockSize = { variable: true };
+
+        // The grid is padded out with the letter X, so the message has to be
+        // drawn from the alphabet X belongs to. Declared here so the
+        // round-trip suite scores a rejection of anything else as a domain
+        // limit, not a defect.
+        this.restrictedInputDomain = true;
 
         this.documentation = [
           new LinkItem('Wikipedia: Transposition Cipher', 'https://en.wikipedia.org/wiki/Transposition_cipher'),
@@ -189,126 +224,74 @@
         return order;
       }
 
+      /**
+       * Find the grid column whose keyword letter sorts into a given place.
+       * @param {number} sortedPosition - Place in keyword-alphabetical order
+       * @returns {number} Index of that column in the grid
+       */
+      columnAt(sortedPosition) {
+        for (let col = 0; col < this._columnOrder.length; col++)
+          if (this._columnOrder[col] === sortedPosition) return col;
+        return -1;
+      }
+
+      /**
+       * Write the message across the grid and read the columns off in
+       * keyword-alphabetical order. The last row is filled out with X first,
+       * so the ciphertext is a whole number of rows.
+       * @param {uint8[]} plaintext - Message bytes, all A-Z
+       * @returns {uint8[]} Transposed bytes
+       */
       EncryptBlock(blockIndex, plaintext) {
-        if (!this._cleanKey || this._cleanKey.length === 0) {
-          return plaintext;
-        }
+        const columns = this._cleanKey.length;
+        const rows = Math.ceil(plaintext.length / columns);
+        const result = new Array(rows * columns);
 
-        const numCols = this._cleanKey.length;
-
-        // Remove non-alphabetic chars, convert to uppercase
-        let cleanText = '';
-        for (let i = 0; i < plaintext.length; i++) {
-          const char = plaintext.charAt(i).toUpperCase();
-          if (char >= 'A' && char <= 'Z') {
-            cleanText += char;
-          }
-        }
-
-        if (cleanText.length === 0) {
-          return '';
-        }
-
-        // Pad text to fill complete rows
-        const numRows = Math.ceil(cleanText.length / numCols);
-        while (cleanText.length < numRows * numCols) {
-          cleanText += 'X'; // Padding character
-        }
-
-        // Create grid
-        const grid = [];
-        for (let row = 0; row < numRows; row++) {
-          grid[row] = [];
-          for (let col = 0; col < numCols; col++) {
-            const charIndex = row * numCols + col;
-            grid[row][col] = charIndex < cleanText.length ? cleanText.charAt(charIndex) : '';
-          }
-        }
-
-        // Read columns in sorted order
-        let result = '';
-        for (let sortedPos = 0; sortedPos < numCols; sortedPos++) {
-          // Find which original column position has this sorted position
-          let originalCol = -1;
-          for (let col = 0; col < numCols; col++) {
-            if (this._columnOrder[col] === sortedPos) {
-              originalCol = col;
-              break;
-            }
-          }
-
-          // Read this column
-          for (let row = 0; row < numRows; row++) {
-            if (grid[row][originalCol]) {
-              result += grid[row][originalCol];
-            }
+        let position = 0;
+        for (let sortedPosition = 0; sortedPosition < columns; sortedPosition++) {
+          const originalCol = this.columnAt(sortedPosition);
+          for (let row = 0; row < rows; row++) {
+            const index = row * columns + originalCol;
+            result[position++] = index < plaintext.length ? plaintext[index] : PAD_LETTER;
           }
         }
 
         return result;
       }
 
+      /**
+       * Refill the grid column by column and read it back row by row, then
+       * drop the trailing X the padding put there. A message that genuinely
+       * ended in X is indistinguishable from padding and comes back short -
+       * the same ambiguity as zero padding, and it is stated in the
+       * description rather than hidden.
+       * @param {uint8[]} ciphertext - Transposed bytes, all A-Z
+       * @returns {uint8[]} Original bytes, less any trailing X
+       */
       DecryptBlock(blockIndex, ciphertext) {
-        if (!this._cleanKey || this._cleanKey.length === 0) {
-          return ciphertext;
+        const columns = this._cleanKey.length;
+        const rows = Math.ceil(ciphertext.length / columns);
+        const baseHeight = Math.floor(ciphertext.length / columns);
+        const remainder = ciphertext.length % columns;
+
+        // -1 marks a cell of a ragged final row, which only a ciphertext this
+        // cipher did not produce can have; those cells are skipped on the way
+        // out rather than emitted as a byte.
+        const grid = new Array(rows * columns).fill(-1);
+
+        let position = 0;
+        for (let sortedPosition = 0; sortedPosition < columns; sortedPosition++) {
+          const originalCol = this.columnAt(sortedPosition);
+          const height = baseHeight + (sortedPosition < remainder ? 1 : 0);
+          for (let row = 0; row < height && position < ciphertext.length; row++)
+            grid[row * columns + originalCol] = ciphertext[position++];
         }
 
-        const numCols = this._cleanKey.length;
-        const cleanText = ciphertext.toUpperCase();
-        const numRows = Math.ceil(cleanText.length / numCols);
+        const result = [];
+        for (let i = 0; i < grid.length; i++)
+          if (grid[i] >= 0) result.push(grid[i]);
 
-        if (cleanText.length === 0) {
-          return '';
-        }
-
-        // Create empty grid
-        const grid = [];
-        for (let row = 0; row < numRows; row++) {
-          grid[row] = new Array(numCols).fill('');
-        }
-
-        // Calculate how many characters each column should get
-        const baseColLength = Math.floor(cleanText.length / numCols);
-        const remainder = cleanText.length % numCols;
-        const colLengths = new Array(numCols).fill(baseColLength);
-
-        // First 'remainder' columns in alphabetical order get an extra character
-        for (let i = 0; i < remainder; i++) {
-          colLengths[i] = baseColLength + 1;
-        }
-
-        // Fill grid column by column in alphabetical order
-        let textPos = 0;
-        for (let alphabeticalOrder = 0; alphabeticalOrder < numCols; alphabeticalOrder++) {
-          // Find which original column position has this alphabetical order
-          let originalCol = -1;
-          for (let col = 0; col < numCols; col++) {
-            if (this._columnOrder[col] === alphabeticalOrder) {
-              originalCol = col;
-              break;
-            }
-          }
-
-          // Fill this column with the appropriate number of characters
-          for (let row = 0; row < colLengths[alphabeticalOrder]; row++) {
-            if (textPos < cleanText.length) {
-              grid[row][originalCol] = cleanText.charAt(textPos++);
-            }
-          }
-        }
-
-        // Read grid row by row to get the original text
-        let result = '';
-        for (let row = 0; row < numRows; row++) {
-          for (let col = 0; col < numCols; col++) {
-            if (grid[row][col]) {
-              result += grid[row][col];
-            }
-          }
-        }
-
-        // Remove padding (trailing X characters that were likely added during encryption)
-        result = result.replace(/X+$/, '');
+        while (result.length > 0 && result[result.length - 1] === PAD_LETTER) result.pop();
 
         return result;
       }
@@ -329,19 +312,21 @@
           return [];
         }
 
-        // Convert input buffer to string
-        const inputString = String.fromCharCode(...this.inputBuffer);
-
-        // Process using the block method
-        const resultString = this.isInverse ? 
-          this.DecryptBlock(0, inputString) : 
-          this.EncryptBlock(0, inputString);
-
-        // Clear input buffer for next operation
+        const message = this.inputBuffer;
         this.inputBuffer = [];
 
-        // Convert result string back to byte array
-        return OpCodes.AnsiToBytes(resultString);
+        // The grid is padded with X, so the message has to be letters. It used
+        // to be filtered down to A-Z instead, which meant a five-byte binary
+        // message encrypted to nothing and decrypted back to nothing with no
+        // error raised.
+        RequireLetters(message);
+
+        // With no keyword there are no columns to read, so the message stands
+        if (!this._cleanKey || this._cleanKey.length === 0) return message;
+
+        return this.isInverse
+          ? this.DecryptBlock(0, message)
+          : this.EncryptBlock(0, message);
       }
     }
 

--- a/Cipher/algorithms/classical/enigma.js
+++ b/Cipher/algorithms/classical/enigma.js
@@ -47,6 +47,17 @@
           IKdfInstance, IAeadInstance, IErrorCorrectionInstance, IRandomGeneratorInstance,
           TestCase, LinkItem, Vulnerability, AuthResult, KeySize } = AlgorithmFramework;
 
+  const UPPER_A = 65, UPPER_Z = 90;
+
+  /**
+   * Printable stand-in for a byte, for use in an error message.
+   * @param {number} byte - Offending byte
+   * @returns {string} The character itself when it is printable ASCII, else '?'
+   */
+  function DescribeByte(byte) {
+    return byte >= 0x20 && byte <= 0x7e ? String.fromCharCode(byte) : '?';
+  }
+
   // ===== ALGORITHM IMPLEMENTATION =====
 
   class EnigmaMachine extends CryptoAlgorithm {
@@ -55,7 +66,7 @@
 
       // Required metadata
       this.name = "Enigma Machine";
-      this.description = "Simplified 3-rotor Enigma machine simulation for educational purposes. Historical WWII cipher machine with rotating mechanical rotors and electrical pathways. Uses reciprocal substitution through rotor wirings and reflector.";
+      this.description = "Simplified 3-rotor Enigma machine simulation for educational purposes. Historical WWII cipher machine with rotating mechanical rotors and electrical pathways. Uses reciprocal substitution through rotor wirings and reflector. Input domain: uppercase A-Z only. The machine is 26 keys, 26 lamps and 26 rotor contacts - it has no key for a digit, a space, a punctuation mark or a lowercase letter, and operators spelled such things out in the plaintext before enciphering. Anything outside A-Z is therefore refused by name and position rather than case-folded or passed through in clear, and A-Z round-trips exactly because the machine is reciprocal.";
       this.inventor = "Arthur Scherbius";
       this.year = 1918;
       this.category = CategoryType.CLASSICAL;
@@ -63,6 +74,12 @@
       this.securityStatus = SecurityStatus.EDUCATIONAL;
       this.complexity = ComplexityType.EXPERT;
       this.country = CountryCode.DE;
+
+      // The machine has 26 keys, 26 lamps and 26 contacts per rotor, and no
+      // notion of case. There is no wiring an out-of-range byte could travel
+      // along, so it is rejected instead. Declared here so the round-trip
+      // suite scores that rejection as a domain limit, not a defect.
+      this.restrictedInputDomain = true;
 
       // Documentation and references
       this.documentation = [
@@ -291,17 +308,12 @@
       return outputChar.charCodeAt(0) - 65;
     }
 
-    // Encrypt a single character
-    encryptChar(char) {
-      if (char < 'A' || char > 'Z') {
-        return char; // Non-alphabetic characters pass through
-      }
-
+    // Encrypt a single letter, given as its 0-25 position in the alphabet
+    encryptLetter(letter) {
       // Step rotors before encryption
       this.stepRotors();
 
-      // Convert to number
-      let current = char.charCodeAt(0) - 65;
+      let current = letter;
 
       // Forward through rotors (right to left)
       current = this.encodeRotorForward(current, 2); // Right rotor
@@ -316,8 +328,7 @@
       current = this.encodeRotorBackward(current, 1); // Middle rotor
       current = this.encodeRotorBackward(current, 2); // Right rotor
 
-      // Convert back to character
-      return String.fromCharCode(current + 65);
+      return current;
     }
 
     // Feed data to the cipher
@@ -346,17 +357,24 @@
         return [];
       }
 
-      const output = [];
-      const inputStr = String.fromCharCode.apply(null, this.inputBuffer);
+      const output = new Array(this.inputBuffer.length);
 
-      // Normalize input to uppercase letters only
-      const normalizedInput = inputStr.toUpperCase();
+      // Process each letter (Enigma is reciprocal, so encryption=decryption).
+      // Anything the keyboard has no key for is refused by name and position.
+      // Uppercasing the message instead, as this did, both silently discarded
+      // case and could change the message length outright: 0xdf uppercases to
+      // "SS", which turned 256 bytes of input into 257 bytes of output.
+      for (let i = 0; i < this.inputBuffer.length; i++) {
+        const byte = this.inputBuffer[i];
 
-      // Process each character (Enigma is reciprocal, so encryption=decryption)
-      for (let i = 0; i < normalizedInput.length; i++) {
-        const char = normalizedInput[i];
-        const encryptedChar = this.encryptChar(char);
-        output.push(encryptedChar.charCodeAt(0));
+        if (byte < UPPER_A || byte > UPPER_Z) {
+          this.inputBuffer = [];
+          throw new Error(`EnigmaMachineInstance.Result: byte 0x${byte.toString(16).padStart(2, '0')}`
+            + ` ('${DescribeByte(byte)}') at position ${i} is not one of the 26 letters A-Z`
+            + ' the machine has keys for');
+        }
+
+        output[i] = UPPER_A + this.encryptLetter(byte - UPPER_A);
       }
 
       // Clear input buffer for next operation

--- a/Cipher/algorithms/classical/enigma.js
+++ b/Cipher/algorithms/classical/enigma.js
@@ -58,6 +58,21 @@
     return byte >= 0x20 && byte <= 0x7e ? String.fromCharCode(byte) : '?';
   }
 
+  /**
+   * Reject the first byte the machine has no key for, naming it and its place.
+   * @param {uint8[]} message - Bytes about to be enciphered
+   * @throws {Error} On the first byte outside A-Z
+   */
+  function RequireLetters(message) {
+    for (let i = 0; i < message.length; i++) {
+      const byte = message[i];
+      if (byte < UPPER_A || byte > UPPER_Z)
+        throw new Error(`EnigmaMachineInstance.Result: byte 0x${byte.toString(16).padStart(2, '0')}`
+          + ` ('${DescribeByte(byte)}') at position ${i} is not one of the 26 letters A-Z`
+          + ' the machine has keys for');
+    }
+  }
+
   // ===== ALGORITHM IMPLEMENTATION =====
 
   class EnigmaMachine extends CryptoAlgorithm {
@@ -357,28 +372,23 @@
         return [];
       }
 
-      const output = new Array(this.inputBuffer.length);
+      const message = this.inputBuffer;
 
-      // Process each letter (Enigma is reciprocal, so encryption=decryption).
-      // Anything the keyboard has no key for is refused by name and position.
-      // Uppercasing the message instead, as this did, both silently discarded
-      // case and could change the message length outright: 0xdf uppercases to
-      // "SS", which turned 256 bytes of input into 257 bytes of output.
-      for (let i = 0; i < this.inputBuffer.length; i++) {
-        const byte = this.inputBuffer[i];
-
-        if (byte < UPPER_A || byte > UPPER_Z) {
-          this.inputBuffer = [];
-          throw new Error(`EnigmaMachineInstance.Result: byte 0x${byte.toString(16).padStart(2, '0')}`
-            + ` ('${DescribeByte(byte)}') at position ${i} is not one of the 26 letters A-Z`
-            + ' the machine has keys for');
-        }
-
-        output[i] = UPPER_A + this.encryptLetter(byte - UPPER_A);
-      }
+      // Anything the keyboard has no key for is refused by name and position,
+      // and the whole message is checked before a single key is pressed so a
+      // refusal does not leave the rotors part-way through it. Uppercasing the
+      // message instead, as this did, both silently discarded case and could
+      // change its length outright: 0xdf uppercases to "SS", which turned 256
+      // bytes of input into 257 bytes of output.
+      RequireLetters(message);
 
       // Clear input buffer for next operation
       this.inputBuffer = [];
+
+      // Process each letter (Enigma is reciprocal, so encryption=decryption)
+      const output = new Array(message.length);
+      for (let i = 0; i < message.length; i++)
+        output[i] = UPPER_A + this.encryptLetter(message[i] - UPPER_A);
 
       return output;
     }

--- a/Cipher/algorithms/classical/scytale.js
+++ b/Cipher/algorithms/classical/scytale.js
@@ -55,7 +55,7 @@
 
       // Required metadata
       this.name = "Scytale Cipher";
-      this.description = "Ancient Spartan transposition cipher using a staff for military communications in classical antiquity.";
+      this.description = "Ancient Spartan transposition cipher using a staff for military communications in classical antiquity. A scytale reorders the marks on a strip of parchment and never looks at what they are, so this implementation accepts every byte: the message is written across a grid of 'circumference' columns and read off column by column, and the inverse puts it back. No byte is dropped, altered, case-folded or padded, and the round trip is exact for arbitrary input of any length.";
       this.category = CategoryType.CLASSICAL;
       this.subCategory = "Transposition Cipher";
       this.securityStatus = SecurityStatus.EDUCATIONAL;
@@ -159,15 +159,10 @@
     Feed(data) {
       if (!data || data.length === 0) return;
 
-      // Convert bytes to string for classical cipher
-      let text = '';
-      if (typeof data === 'string') {
-        text = data;
-      } else {
-        text = String.fromCharCode(...data);
-      }
-
-      this.inputBuffer.push(text);
+      // The strip is wound round the staff as it is, so the bytes are buffered
+      // as bytes. Converting the message to a string here was what let the
+      // A-Z filter downstream throw most of it away.
+      for (let i = 0; i < data.length; i++) this.inputBuffer.push(data[i]);
     }
 
     /**
@@ -179,89 +174,53 @@
     Result() {
       if (this.inputBuffer.length === 0) return [];
 
-      const text = this.inputBuffer.join('');
+      const message = this.inputBuffer;
       this.inputBuffer = [];
 
-      const result = this.isInverse ? 
-        this.decryptText(text) : 
-        this.encryptText(text);
-
-      // Convert string result to bytes
-      return Array.from(result).map(c => c.charCodeAt(0));
+      return this.isInverse ? this.unwind(message) : this.wind(message);
     }
 
-    encryptText(plaintext) {
-      const text = plaintext.toUpperCase().replace(/[^A-Z]/g, '');
-      if (text.length === 0) return '';
+    /**
+     * Wind the message round the staff: write it across the rows of a grid
+     * 'circumference' columns wide, then read it off column by column. The
+     * last row may be short and is simply left short - no padding is added,
+     * so the ciphertext is exactly as long as the plaintext.
+     * @param {uint8[]} plaintext - Message bytes
+     * @returns {uint8[]} Transposed bytes
+     */
+    wind(plaintext) {
+      const columns = this.circumference;
+      const rows = Math.ceil(plaintext.length / columns);
+      const result = new Array(plaintext.length);
 
-      // Calculate rows needed
-      const rows = Math.ceil(text.length / this.circumference);
-      const grid = [];
-
-      // Fill grid row by row
-      for (let r = 0; r < rows; r++) {
-        grid[r] = [];
-        for (let c = 0; c < this.circumference; c++) {
-          const index = r * this.circumference + c;
-          grid[r][c] = index < text.length ? text[index] : '';
-        }
-      }
-
-      // Read column by column
-      let result = '';
-      for (let c = 0; c < this.circumference; c++) {
+      let position = 0;
+      for (let c = 0; c < columns; c++) {
         for (let r = 0; r < rows; r++) {
-          if (grid[r][c]) {
-            result += grid[r][c];
-          }
+          const index = r * columns + c;
+          if (index < plaintext.length) result[position++] = plaintext[index];
         }
       }
 
       return result;
     }
 
-    decryptText(ciphertext) {
-      const text = ciphertext.toUpperCase().replace(/[^A-Z]/g, '');
-      if (text.length === 0) return '';
+    /**
+     * Unwind the message from the staff. Column c holds one byte per full row
+     * plus one more when c is among the first (length mod circumference)
+     * columns, which is exactly the shape wind() produced.
+     * @param {uint8[]} ciphertext - Transposed bytes
+     * @returns {uint8[]} Original bytes
+     */
+    unwind(ciphertext) {
+      const columns = this.circumference;
+      const fullRows = Math.floor(ciphertext.length / columns);
+      const remainder = ciphertext.length % columns;
+      const result = new Array(ciphertext.length);
 
-      const rows = Math.ceil(text.length / this.circumference);
-      const grid = [];
-
-      // Initialize grid
-      for (let r = 0; r < rows; r++) {
-        grid[r] = new Array(this.circumference).fill('');
-      }
-
-      // Calculate how many characters each column should have
-      // When text.length is not divisible by circumference, 
-      // some columns will have one less character
-      const charsPerColumn = [];
-      const fullRows = Math.floor(text.length / this.circumference);
-      const remainder = text.length % this.circumference;
-
-      for (let c = 0; c < this.circumference; c++) {
-        // First 'remainder' columns get an extra character
-        charsPerColumn[c] = fullRows + (c < remainder ? 1 : 0);
-      }
-
-      // Fill the grid column by column with the correct number of characters
-      let cipherIndex = 0;
-      for (let c = 0; c < this.circumference; c++) {
-        for (let r = 0; r < charsPerColumn[c]; r++) {
-          if (cipherIndex < text.length) {
-            grid[r][c] = text[cipherIndex++];
-          }
-        }
-      }
-
-      // Read row by row to get original plaintext
-      let result = '';
-      for (let r = 0; r < rows; r++) {
-        for (let c = 0; c < this.circumference; c++) {
-          if (grid[r][c] && grid[r][c] !== '') {
-            result += grid[r][c];
-          }
-        }
+      let position = 0;
+      for (let c = 0; c < columns; c++) {
+        const height = fullRows + (c < remainder ? 1 : 0);
+        for (let r = 0; r < height; r++) result[r * columns + c] = ciphertext[position++];
       }
 
       return result;

--- a/Cipher/algorithms/classical/solitaire.js
+++ b/Cipher/algorithms/classical/solitaire.js
@@ -47,6 +47,17 @@
           IKdfInstance, IAeadInstance, IErrorCorrectionInstance, IRandomGeneratorInstance,
           TestCase, LinkItem, Vulnerability, AuthResult, KeySize } = AlgorithmFramework;
 
+  const UPPER_A = 65, UPPER_Z = 90;
+
+  /**
+   * Printable stand-in for a byte, for use in an error message.
+   * @param {number} byte - Offending byte
+   * @returns {string} The character itself when it is printable ASCII, else '?'
+   */
+  function DescribeByte(byte) {
+    return byte >= 0x20 && byte <= 0x7e ? String.fromCharCode(byte) : '?';
+  }
+
   // ===== ALGORITHM IMPLEMENTATION =====
 
   class SolitaireCipher extends CryptoAlgorithm {
@@ -55,7 +66,7 @@
 
       // Required metadata
       this.name = "Solitaire Cipher";
-      this.description = "Bruce Schneier's card-based stream cipher designed for manual use without computer assistance from Neal Stephenson's Cryptonomicon.";
+      this.description = "Bruce Schneier's card-based stream cipher designed for manual use without computer assistance from Neal Stephenson's Cryptonomicon. Input domain: uppercase A-Z only. The deck yields a keystream value of 1 to 26 which is added to a letter of the alphabet modulo 26; the pencil-and-paper procedure has the operator strip punctuation and case from the message before starting, and there is no card value that could carry a digit, a space or a high-bit byte. Anything outside A-Z is therefore refused by name and position rather than dropped, and A-Z round-trips exactly.";
       this.category = CategoryType.CLASSICAL;
       this.subCategory = "Stream Cipher";
       this.securityStatus = SecurityStatus.EDUCATIONAL;
@@ -63,6 +74,12 @@
       this.inventor = "Bruce Schneier";
       this.year = 1999;
       this.country = CountryCode.US;
+
+      // The keystream is a card value of 1 to 26 added to a letter modulo 26.
+      // Nothing outside A-Z has a place in that arithmetic, so it is rejected
+      // instead. Declared here so the round-trip suite scores that rejection
+      // as a domain limit, not a defect.
+      this.restrictedInputDomain = true;
 
       // Documentation
       this.documentation = [
@@ -165,15 +182,9 @@
     Feed(data) {
       if (!data || data.length === 0) return;
 
-      // Convert bytes to string for classical cipher
-      let text = '';
-      if (typeof data === 'string') {
-        text = data;
-      } else {
-        text = String.fromCharCode(...data);
-      }
-
-      this.inputBuffer.push(text);
+      // Buffered as bytes: converting to a string here was what let the A-Z
+      // filter downstream throw most of the message away.
+      for (let i = 0; i < data.length; i++) this.inputBuffer.push(data[i]);
     }
 
     /**
@@ -185,15 +196,34 @@
     Result() {
       if (this.inputBuffer.length === 0) return [];
 
-      const text = this.inputBuffer.join('');
+      const message = this.inputBuffer;
       this.inputBuffer = [];
 
-      const result = this.isInverse ? 
-        this.decryptText(text) : 
-        this.encryptText(text);
+      const output = new Array(message.length);
 
-      // Convert string result to bytes
-      return Array.from(result).map(c => c.charCodeAt(0));
+      // One card value per letter. Anything the deck cannot carry is refused
+      // by name and position; the previous filter dropped it instead, so a
+      // five-byte binary message encrypted to nothing and decrypted back to
+      // nothing with no error raised.
+      for (let i = 0; i < message.length; i++) {
+        const byte = message[i];
+
+        if (byte < UPPER_A || byte > UPPER_Z)
+          throw new Error(`SolitaireInstance.Result: byte 0x${byte.toString(16).padStart(2, '0')}`
+            + ` ('${DescribeByte(byte)}') at position ${i} is outside the A-Z alphabet the deck encodes`);
+
+        const keyValue = this.stepDeck();
+        const letter = byte - UPPER_A;
+
+        // Encryption adds the card value, decryption takes it away again
+        const result = this.isInverse
+          ? (letter - keyValue + 1 + 26) % 26
+          : (letter + keyValue - 1) % 26;
+
+        output[i] = UPPER_A + result;
+      }
+
+      return output;
     }
 
     initializeDeck() {
@@ -230,34 +260,6 @@
 
       // Simplified for demonstration
       return this.deck[0] % 26 + 1;
-    }
-
-    encryptText(plaintext) {
-      const text = plaintext.toUpperCase().replace(/[^A-Z]/g, '');
-      let result = '';
-
-      for (let i = 0; i < text.length; i++) {
-        const keyValue = this.stepDeck();
-        const plainChar = text.charCodeAt(i) - 65; // A=0, B=1, etc.
-        const cipherChar = (plainChar + keyValue - 1) % 26;
-        result += String.fromCharCode(cipherChar + 65);
-      }
-
-      return result;
-    }
-
-    decryptText(ciphertext) {
-      const text = ciphertext.toUpperCase().replace(/[^A-Z]/g, '');
-      let result = '';
-
-      for (let i = 0; i < text.length; i++) {
-        const keyValue = this.stepDeck();
-        const cipherChar = text.charCodeAt(i) - 65; // A=0, B=1, etc.
-        const plainChar = (cipherChar - keyValue + 1 + 26) % 26;
-        result += String.fromCharCode(plainChar + 65);
-      }
-
-      return result;
     }
   }
 

--- a/Cipher/algorithms/classical/solitaire.js
+++ b/Cipher/algorithms/classical/solitaire.js
@@ -58,6 +58,20 @@
     return byte >= 0x20 && byte <= 0x7e ? String.fromCharCode(byte) : '?';
   }
 
+  /**
+   * Reject the first byte the deck cannot encode, naming it and its place.
+   * @param {uint8[]} message - Bytes about to be enciphered
+   * @throws {Error} On the first byte outside A-Z
+   */
+  function RequireLetters(message) {
+    for (let i = 0; i < message.length; i++) {
+      const byte = message[i];
+      if (byte < UPPER_A || byte > UPPER_Z)
+        throw new Error(`SolitaireInstance.Result: byte 0x${byte.toString(16).padStart(2, '0')}`
+          + ` ('${DescribeByte(byte)}') at position ${i} is outside the A-Z alphabet the deck encodes`);
+    }
+  }
+
   // ===== ALGORITHM IMPLEMENTATION =====
 
   class SolitaireCipher extends CryptoAlgorithm {
@@ -197,21 +211,20 @@
       if (this.inputBuffer.length === 0) return [];
 
       const message = this.inputBuffer;
+
+      // Anything the deck cannot carry is refused by name and position, and
+      // the whole message is checked before the first cut so a refusal does
+      // not leave the deck part-way through it. The previous filter dropped
+      // such bytes instead, so a five-byte binary message encrypted to nothing
+      // and decrypted back to nothing with no error raised.
+      RequireLetters(message);
+
       this.inputBuffer = [];
 
+      // One card value per letter
       const output = new Array(message.length);
-
-      // One card value per letter. Anything the deck cannot carry is refused
-      // by name and position; the previous filter dropped it instead, so a
-      // five-byte binary message encrypted to nothing and decrypted back to
-      // nothing with no error raised.
       for (let i = 0; i < message.length; i++) {
         const byte = message[i];
-
-        if (byte < UPPER_A || byte > UPPER_Z)
-          throw new Error(`SolitaireInstance.Result: byte 0x${byte.toString(16).padStart(2, '0')}`
-            + ` ('${DescribeByte(byte)}') at position ${i} is outside the A-Z alphabet the deck encodes`);
-
         const keyValue = this.stepDeck();
         const letter = byte - UPPER_A;
 

--- a/Cipher/algorithms/classical/vigenere.js
+++ b/Cipher/algorithms/classical/vigenere.js
@@ -46,6 +46,19 @@
           IKdfInstance, IAeadInstance, IErrorCorrectionInstance, IRandomGeneratorInstance,
           TestCase, LinkItem, Vulnerability, AuthResult, KeySize } = AlgorithmFramework;
 
+  const UPPER_A = 65, UPPER_Z = 90, LOWER_A = 97, LOWER_Z = 122;
+
+  /**
+   * Alphabet origin of a byte: 65 for A-Z, 97 for a-z, -1 for anything else.
+   * @param {number} byte - Input byte
+   * @returns {number} Character code of the letter's own 'A', or -1
+   */
+  function LetterCaseBase(byte) {
+    if (byte >= UPPER_A && byte <= UPPER_Z) return UPPER_A;
+    if (byte >= LOWER_A && byte <= LOWER_Z) return LOWER_A;
+    return -1;
+  }
+
   // ===== ALGORITHM IMPLEMENTATION =====
 
   class VigenereCipher extends CryptoAlgorithm {
@@ -54,7 +67,7 @@
 
       // Required metadata
       this.name = "Vigenère Cipher";
-      this.description = "Classical polyalphabetic substitution cipher using repeating keyword to shift letters. Developed by Blaise de Vigenère in 16th century, considered unbreakable for centuries until Kasiski examination was developed. Uses Caesar cipher with different shift for each position.";
+      this.description = "Classical polyalphabetic substitution cipher using repeating keyword to shift letters. Developed by Blaise de Vigenère in 16th century, considered unbreakable for centuries until Kasiski examination was developed. Uses Caesar cipher with different shift for each position. Input domain: every byte is accepted. A-Z and a-z are enciphered in place with their case preserved and advance the keyword; every other byte - digit, punctuation, whitespace, control or high-bit - is carried through unchanged and leaves the keyword position alone, which is the usual pen-and-paper convention and makes the round trip exact for arbitrary input. Nothing is ever discarded.";
       this.inventor = "Blaise de Vigenère";
       this.year = 1553;
       this.category = CategoryType.CLASSICAL;
@@ -219,34 +232,35 @@
         return [];
       }
 
-      const output = [];
+      const output = new Array(this.inputBuffer.length);
       const processedKey = this.key;
-      const inputStr = String.fromCharCode.apply(null, this.inputBuffer);
 
-      // Normalize input to uppercase letters only
-      const normalizedInput = inputStr.toUpperCase().replace(/[^A-Z]/g, '');
+      // Every byte is accounted for. A letter is enciphered in its own case
+      // and consumes one keyword position; anything else is copied through
+      // untouched and does not move the keyword on, which is how the cipher
+      // has always been worked by hand over a text that carries punctuation.
+      // The earlier "uppercase and strip everything but A-Z" normalisation
+      // silently shortened the message - five binary bytes came back as none.
+      let keyPosition = 0;
+      for (let i = 0; i < this.inputBuffer.length; i++) {
+        const byte = this.inputBuffer[i];
+        const caseBase = LetterCaseBase(byte);
 
-      // Process each character
-      for (let i = 0; i < normalizedInput.length; i++) {
-        const textChar = normalizedInput[i];
-        const keyChar = processedKey[i % processedKey.length];
-
-        const textIndex = this.ALPHABET.indexOf(textChar);
-        const keyIndex = this.ALPHABET.indexOf(keyChar);
-
-        if (textIndex !== -1 && keyIndex !== -1) {
-          let resultIndex;
-          if (this.isInverse) {
-            // Vigenère decryption: (cipher - key + 26) mod 26
-            resultIndex = (textIndex - keyIndex + 26) % 26;
-          } else {
-            // Vigenère encryption: (text + key) mod 26
-            resultIndex = (textIndex + keyIndex) % 26;
-          }
-
-          const resultChar = this.ALPHABET[resultIndex];
-          output.push(resultChar.charCodeAt(0));
+        if (caseBase < 0) {
+          output[i] = byte;
+          continue;
         }
+
+        const textIndex = byte - caseBase;
+        const keyIndex = this.ALPHABET.indexOf(processedKey[keyPosition % processedKey.length]);
+        ++keyPosition;
+
+        // Vigenère: encryption (text + key) mod 26, decryption (cipher - key) mod 26
+        const resultIndex = this.isInverse
+          ? (textIndex - keyIndex + 26) % 26
+          : (textIndex + keyIndex) % 26;
+
+        output[i] = caseBase + resultIndex;
       }
 
       // Clear input buffer for next operation

--- a/Cipher/tests/RoundTripSuite.js
+++ b/Cipher/tests/RoundTripSuite.js
@@ -397,13 +397,16 @@ function buildCipherCorpus(algorithm, vector) {
   // how FFX turned 16 bytes into 46. Without this case either could lose its
   // domain check and no in-alphabet corpus would ever notice.
   //
-  // Applied to modes and padding only. The classical ciphers do not survive it:
-  // Affine, Autokey, Beaufort, Columnar Transposition, Enigma Machine, Scytale,
-  // Solitaire and Vigenere all discard bytes outside A-Z instead of rejecting
-  // them, so a five-byte message comes back empty. That is the same defect this
-  // case exists to catch and it is recorded here rather than papered over, but
-  // repairing eight classical ciphers is separate work from the modes and
-  // padding schemes this tier was added for.
+  // Applied to modes and padding only, which is the tier it was added for. The
+  // eight classical ciphers that used to fail it - Affine, Autokey, Beaufort,
+  // Columnar Transposition, Enigma Machine, Scytale, Solitaire and Vigenere all
+  // discarded bytes outside A-Z, so a five-byte message came back empty - have
+  // since been repaired and each now states its domain: the four polyalphabetic
+  // substitutions and Scytale carry any byte through exactly, and Enigma,
+  // Solitaire and Columnar Transposition refuse one by name and position. The
+  // remaining classical ciphers have not all been through that work yet, so
+  // extending this case to the whole category would report their defects here
+  // rather than where they belong.
   if (alphabet.size < 256 && DOMAIN_CHECKED_CATEGORIES.has(algorithm.category.name))
     cases.push({ name: 'outside alphabet', data: alphabetData(unit, { base: 0, size: 256 }, 0x0f1e2d3c) });
   return cases;

--- a/Cipher/tests/RoundTripSuite.js
+++ b/Cipher/tests/RoundTripSuite.js
@@ -440,6 +440,11 @@ const ROUND_TRIP_EXEMPT = new Map([
   // Verified: "ABCX" comes back as "ABC" and "ZRDSSTNX" as "ZRDSSTN".
   ['Hill Cipher', 'pads the message to a whole block with X and strips trailing X again, so a '
     + 'message that genuinely ends in X comes back short - the same ambiguity as zero padding'],
+  // Refuses anything outside A-Z by name and position, so only this one
+  // normalisation is left. Verified: "HELLX" comes back as "HELL".
+  ['Columnar Transposition', 'complete columnar transposition fills the last row of the grid with X '
+    + 'and strips trailing X again, so a message that genuinely ends in X comes back short - the '
+    + 'same ambiguity as zero padding'],
   ['Jefferson Wheel', 'wheel alphabets normalise the plaintext to the 26 letters they carry'],
 
   // --- already failing their own committed vectors ---


### PR DESCRIPTION
Eight classical ciphers silently discarded every byte outside A-Z, so a short
binary message encrypted to something that decrypted back to **nothing**, with no
error raised. Silent data loss was the defect; the fix differs per cipher because
the right answer does.

## Accept every byte, encipher letters in place, carry the rest through
**Affine, Vigenère, Beaufort, Autokey**

These are pen-and-paper polyalphabetic substitutions worked over written text that
carries punctuation. Passing non-letters through and advancing the keyword only on
letters is the conventional reading. Upper and lower case are each enciphered in
their own case rather than folded. Round-trip is now exact for arbitrary binary at
every length tested, including all 256 byte values.

## Accept every byte and transpose it
**Scytale**

A scytale reorders marks on a strip of parchment and never inspects them, so the
alphabet filter was pure loss with no basis in the mechanism. The grid arithmetic
now runs over the byte array and the short last row stays short rather than being
padded.

## Refuse, naming the byte and its position
**Enigma, Solitaire, Columnar Transposition**

Enigma is 26 keys, 26 lamps and 26 contacts per rotor, with no notion of case —
there is no wiring an out-of-range byte could travel along. Solitaire's deck
yields a value of 1–26 added to a letter mod 26, and the published procedure has
the operator strip case and punctuation first. Columnar fills its last grid row
with the letter X, so the message must come from the alphabet X belongs to. Each
now sets `restrictedInputDomain` and reports in the style of `morse.js`.

## Two judgement calls worth stating

**Enigma loses a capability.** It previously passed punctuation through in clear,
which is option 3 as implemented. That was narrowed to a refusal deliberately:
passing plaintext through a cipher *in clear* is worse than refusing it, and the
machine's domain is unambiguous.

**Columnar cannot round-trip exactly.** Its committed vectors encode the X padding
(`HELLO` → `EOHLLX`), and `HELLOX` encrypts to the same six letters, so stripping
is irreducibly ambiguous. It is recorded in the exemption table with that reason,
alongside Hill Cipher. Everything outside A-Z now refuses loudly, so that single
normalisation is all that remains.

## Two further defects found while working

**Enigma could change the message length.** `toUpperCase()` maps `0xdf` to `"SS"`,
so 256 bytes in produced 257 bytes out. The domain check removes it.

**Autokey was quadratic.** The running key was built with `+=` and then indexed,
forcing the engine to flatten the rope on every letter — the 1 MB tier took
**165,662 ms**. Holding the key as alphabet positions brings that to **63 ms**.

Also caught in review: hoisting the Columnar domain check into `Result()` had
taken the "no keyword" guard with it, so a direct `EncryptBlock` call with no key
divided by zero; and Enigma and Solitaire originally refused mid-loop, leaving the
rotors and deck part-way through the message. Both now validate the whole message
before starting.

## Verification

- `TestSuite.js` 5574/5574, exit 0, every committed vector unchanged
- `RoundTripSuite.js` 611 passed, 0 failed
- 1 MB tier per cipher: Affine 49 ms, Scytale 42 ms, Beaufort 56 ms, Autokey
  63 ms, Vigenère 74 ms all ok; Enigma and Solitaire report a declared domain;
  Columnar is the one exemption. Before this work all eight returned CONTENT
  DIFFERS there.
- Edge sweep: lengths 0–40 exact for all eight; identical ciphertext when the
  message is split across three `Feed` calls; Scytale exact over circumferences
  1–8 by lengths 0–20 of arbitrary bytes; the four pass-through ciphers exact over
  binary lengths 0–64

## Known remaining

`Classical Ciphers` was deliberately **not** added to `DOMAIN_CHECKED_CATEGORIES`:
six ciphers outside this scope — Caesar, Gronsfeld, Porta, Rail Fence, Pigpen and
Bazeries — still discard non-alphabet bytes and would fail that shared check.
