### PR TITLE
Require the out-of-alphabet case of every classical cipher

### DIFF
--- a/Cipher/tests/RoundTripSuite.js
+++ b/Cipher/tests/RoundTripSuite.js
@@ -331,7 +331,7 @@ const WHOLE_BLOCK_CATEGORIES = new Set(['Block Ciphers', 'Special Algorithms']);
 
 // Categories additionally driven with input outside their declared alphabet, to
 // prove they refuse it rather than silently folding it into range.
-const DOMAIN_CHECKED_CATEGORIES = new Set(['Cipher Modes', 'Padding Schemes']);
+const DOMAIN_CHECKED_CATEGORIES = new Set(['Cipher Modes', 'Padding Schemes', 'Classical Ciphers']);
 
 function isCipherCategory(algorithm) {
   return Boolean(algorithm.category && CIPHER_CATEGORIES.has(algorithm.category.name));


### PR DESCRIPTION
The classical ciphers were deliberately excluded from the out-of-alphabet check
because six of them had never been examined, and including them would have
reported their defects in the shared run rather than where they belonged.

Measuring them settled the question: **Caesar, Gronsfeld, Porta, Rail Fence,
Pigpen and Bazeries all round-trip the full 0–255 range exactly**, high-bit bytes
and lowercase included, because they carry non-letters through unchanged. The
caution was unfounded.

With the eight ciphers repaired in the previous change alongside them, every
classical cipher now either passes an out-of-alphabet byte through untouched or
refuses it by name and position. So the case can be required of the whole
category, and a future cipher that silently swallows bytes will be caught on the
way in rather than years later.

## The check is not vacuous

Enabling a test that immediately passes proves nothing on its own, so I mutated
Caesar to drop non-alphabetic characters — precisely the defect this case exists
to catch:

```
0 passed, 1 failed    (mutation applied)
1 passed, 0 failed    (restored)
```

## Verification

- `RoundTripSuite.js` 611 passed, 0 failed, 3 restricted domain, 23 exempt
- `TestSuite.js` 5574/5574, exit 0
