### PR TITLE
FROG, SC2000 and SPEED were fabrications; HPC had five real defects

### DIFF
--- a/Cipher/algorithms/block/frog.js
+++ b/Cipher/algorithms/block/frog.js
@@ -1,3 +1,52 @@
+/*
+ * FROG Implementation
+ * Compatible with AlgorithmFramework
+ * (c)2006-2025 Hawkynt
+ *
+ * FROG, by Dianelos Georgoudis, Damian Leroux and Billy Simon Chaves (TecApro
+ * International), submitted to the AES competition in 1998. Its defining feature
+ * is that the user key is not used by the round function at all: it only derives
+ * a large key-dependent "internal key" of per-round substitution and permutation
+ * tables, and the encryption primitive is then a short fixed sequence of byte
+ * operations driven entirely by those tables.
+ *
+ * Construction (AES submission, "The FROG Encryption Algorithm", sections 3-5):
+ *  1. A 251-byte "random seed" table is built from the first 251 five-digit
+ *     groups of the RAND Corporation's "A Million Random Digits with 100,000
+ *     Normal Deviates" (1955), each group read as a decimal integer and reduced
+ *     mod 256. This is the same nothing-up-my-sleeve source Merkle used for
+ *     Khufu/Khafre/Snefru.
+ *  2. simpleKey[i] = seed[i mod 251] XOR key[i mod keyLength], over the full
+ *     internal key length (blockLength * 2 + 256) * rounds = 2304 bytes for a
+ *     128-bit block and the specified 8 rounds.
+ *  3. simpleKey is cut into one record per round, each holding xorBu[16],
+ *     substPermu[256] and bombPermu[16]. substPermu and bombPermu are each
+ *     turned into a genuine permutation by the key-driven shuffle
+ *     makePermutation; bombPermu is then forced into a single full-length cycle
+ *     (make1Cycle) and stripped of references that the round function's "next
+ *     byte" step would cancel out (removeReferences).
+ *  4. An IV seeded from the user key (iv[i] ^= key[i], iv[0] ^= keyLength) is
+ *     repeatedly FROG-encrypted under that intermediate internal key, OFB
+ *     fashion, to produce the FINAL internal key material, which is cut up and
+ *     permuted exactly the same way.
+ *
+ * Round function, for each byte i of the state in ascending order:
+ *     state[i] = substPermu[state[i] XOR xorBu[i]]
+ *     state[(i + 1) mod blockLength] ^= state[i]
+ *     state[bombPermu[i]] ^= state[i]
+ * Decryption runs the rounds in reverse, the bytes in descending order, and each
+ * byte's three steps in reverse, with substPermu replaced by its inverse:
+ *     state[bombPermu[i]] ^= state[i]
+ *     state[(i + 1) mod blockLength] ^= state[i]
+ *     state[i] = substPermuInverse[state[i]] XOR xorBu[i]
+ * make1Cycle and removeReferences are what make this reversible: they guarantee
+ * bombPermu[i] is neither i nor (i + 1) mod blockLength, so the two XOR steps
+ * touch distinct bytes and neither disturbs state[i] itself.
+ *
+ * 128-bit block, 128/192/256-bit keys, 8 rounds. Broken by Wagner, Ferguson and
+ * Schneier at the AES conference; educational only.
+ */
+
 (function (root, factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD
@@ -31,266 +80,382 @@
 
   // Extract framework components
   const { RegisterAlgorithm, CategoryType, SecurityStatus, ComplexityType, CountryCode,
-          BlockCipherAlgorithm, IBlockCipherInstance, LinkItem, KeySize } = AlgorithmFramework;
+          BlockCipherAlgorithm, IBlockCipherInstance, LinkItem, Vulnerability, KeySize } = AlgorithmFramework;
+
+  // ===== CONSTANTS =====
+
+  const ROUNDS = 8;
+  const BLOCK_LEN = 16;
+
+  // First 251 five-digit groups of "A Million Random Digits with 100,000 Normal
+  // Deviates" (RAND Corporation, 1955), each read as a decimal integer and
+  // reduced mod 256 - the seed table specified in the FROG AES submission.
+  const RAND_DIGITS =
+    "100973253376520135863467354876809590911739292749453754204805648947429624" +
+    "805240372063610402008229166508422689531964509303232090256015953347643508" +
+    "033606990190252909376707153831131165886767439704436276591280799970801573" +
+    "614764032366539895116877121717683366065747173407276850366973617065813398" +
+    "851119929170310601080545571824063530342614867990743923403097328526977602" +
+    "020516569268665748187305385247186238857963573321350532547048905535754828" +
+    "468287098349125624737964575303529647783580834282609352034435273884359852" +
+    "017767149056860722109405586097093433505007399811805054313980827732507256" +
+    "824829405242015277567851834529963406288980831374670078184754061068711778" +
+    "178868540200865075840136766679519036476493296091106299594673488751764969" +
+    "918260892893785613682347834113654811767417468509505804776974730395718640" +
+    "218165448012435635177270801545318223742111578253143855376374350998177740" +
+    "277214432360021045521642379628602655699162680366252291483693687203766211" +
+    "399094400564180989320505142256851446427567889629778822543821459891499145" +
+    "236847927686461628355494750899233708920048803369459826940368587029734135" +
+    "531403334042050823414410481949851574795432979265755760040881222220641312" +
+    "550737421110002040128607469796644894392870725815636064932916505344844021" +
+    "9525634365177082072073179061196";
+
+  function buildRandomSeed() {
+    const seed = new Array(251);
+    for (let i = 0; i < 251; ++i) {
+      seed[i] = parseInt(RAND_DIGITS.substr(i * 5, 5), 10) % 256;
+    }
+    return seed;
+  }
+
+  const RANDOM_SEED = buildRandomSeed();
+
+  // ===== INTERNAL KEY CONSTRUCTION =====
+
+  // Turns an arbitrary byte array into a permutation of its own index range by a
+  // key-driven selection sweep: at each step the next unused value is chosen at
+  // an offset given by the incoming byte. FROG AES submission, "makePermutation".
+  function makePermutation(input) {
+    const length = input.length;
+    const use = new Array(length);
+    for (let i = 0; i < length; ++i) use[i] = i;
+
+    let index = 0;
+    let last = length - 1;
+    for (let i = 0; i < length - 1; ++i) {
+      index = (index + input[i]) % (last + 1);
+      input[i] = use[index];
+      if (index < last) use.splice(index, 1);
+      --last;
+      if (index > last) index = 0;
+    }
+    input[length - 1] = use[0];
+  }
+
+  function invertPermutation(permutation) {
+    const inverse = new Array(permutation.length);
+    for (let i = 0; i < permutation.length; ++i) inverse[permutation[i]] = i;
+    for (let i = 0; i < permutation.length; ++i) permutation[i] = inverse[i];
+  }
+
+  // Merges any shorter cycles of bombPermu into one full-length cycle, so that
+  // every byte position is reachable from every other. FROG AES submission,
+  // "make1Cycle". A side effect is that bombPermu[i] is never i, which is what
+  // keeps the round function's third step from cancelling its own input.
+  function make1Cycle(bombPermu, blockLength) {
+    const used = new Array(blockLength).fill(0);
+    let j = 0;
+    for (let i = 0; i < blockLength - 1; ++i) {
+      if (bombPermu[j] === 0) {
+        let k = j;
+        do {
+          k = (k + 1) % blockLength;
+        } while (used[k] !== 0);
+        bombPermu[j] = k;
+        let l = k;
+        while (bombPermu[l] !== k) l = bombPermu[l];
+        bombPermu[l] = 0;
+      }
+      used[j] = 1;
+      j = bombPermu[j];
+    }
+  }
+
+  // Stops bombPermu[i] pointing at the byte the round function's second step
+  // already XORs, which would otherwise undo it. FROG AES submission,
+  // "removeReferences".
+  function removeReferences(bombPermu, blockLength) {
+    for (let i = 0; i < blockLength; ++i) {
+      const j = (i + 1) % blockLength;
+      if (bombPermu[i] === j) bombPermu[i] = (j + 1) % blockLength;
+    }
+  }
+
+  // Cuts a flat internal-key byte array into one record per round.
+  function toStructuredKey(bytes, blockLength, rounds) {
+    const subkeyLength = bytes.length / rounds;
+    const result = new Array(rounds);
+    for (let r = 0; r < rounds; ++r) {
+      const offsetXorBu = r * subkeyLength;
+      const offsetSubstPermu = offsetXorBu + blockLength;
+      const offsetBombPermu = offsetSubstPermu + 256;
+      result[r] = {
+        xorBu: bytes.slice(offsetXorBu, offsetSubstPermu),
+        substPermu: bytes.slice(offsetSubstPermu, offsetBombPermu),
+        bombPermu: bytes.slice(offsetBombPermu, offsetBombPermu + blockLength)
+      };
+    }
+    return result;
+  }
+
+  function makeInternalKey(bytes, blockLength, rounds, invert) {
+    const structuredKey = toStructuredKey(bytes, blockLength, rounds);
+    for (let r = 0; r < rounds; ++r) {
+      const record = structuredKey[r];
+      makePermutation(record.substPermu);
+      if (invert) invertPermutation(record.substPermu);
+      makePermutation(record.bombPermu);
+      make1Cycle(record.bombPermu, blockLength);
+      removeReferences(record.bombPermu, blockLength);
+    }
+    return structuredKey;
+  }
+
+  // ===== BLOCK TRANSFORM =====
+
+  function frogEncrypt(state, roundKeys) {
+    for (let r = 0; r < roundKeys.length; ++r) {
+      const record = roundKeys[r];
+      for (let i = 0; i < state.length; ++i) {
+        state[i] = record.substPermu[OpCodes.XorN(state[i], record.xorBu[i])];
+        state[(i + 1) % state.length] ^= state[i];
+        state[record.bombPermu[i]] ^= state[i];
+      }
+    }
+  }
+
+  function frogDecrypt(state, roundKeys) {
+    for (let r = roundKeys.length - 1; r >= 0; --r) {
+      const record = roundKeys[r];
+      for (let i = state.length - 1; i >= 0; --i) {
+        state[record.bombPermu[i]] ^= state[i];
+        state[(i + 1) % state.length] ^= state[i];
+        state[i] = OpCodes.XorN(record.substPermu[state[i]], record.xorBu[i]);
+      }
+    }
+  }
+
+  // ===== KEY SCHEDULE =====
+
+  function generateKeys(keyBytes, blockLength, rounds, invert) {
+    const keyLength = keyBytes.length;
+    const internalKeyLength = (blockLength * 2 + 256) * rounds;
+
+    const simpleKey = new Array(internalKeyLength);
+    for (let i = 0; i < internalKeyLength; ++i) {
+      simpleKey[i] = OpCodes.XorN(RANDOM_SEED[i % 251], keyBytes[i % keyLength]);
+    }
+
+    const intermediateKey = makeInternalKey(simpleKey, blockLength, rounds, false);
+
+    // Self-keying pass: an IV derived from the user key is encrypted over and
+    // over under the intermediate internal key, OFB fashion, and the output
+    // stream becomes the final internal key material.
+    const iv = new Array(blockLength).fill(0);
+    const ivLength = Math.min(keyLength, blockLength);
+    for (let i = 0; i < ivLength; ++i) iv[i] ^= keyBytes[i];
+    iv[0] ^= keyLength;
+
+    const material = new Array(internalKeyLength);
+    let filled = 0;
+    while (filled < internalKeyLength) {
+      frogEncrypt(iv, intermediateKey);
+      const chunk = Math.min(blockLength, internalKeyLength - filled);
+      for (let j = 0; j < chunk; ++j) material[filled + j] = iv[j];
+      filled += chunk;
+    }
+
+    return makeInternalKey(material, blockLength, rounds, invert);
+  }
 
   // ===== ALGORITHM IMPLEMENTATION =====
 
+  class FROG extends BlockCipherAlgorithm {
+    constructor() {
+      super();
 
-class FROG extends BlockCipherAlgorithm {
-  constructor() {
-    super();
+      this.name = "FROG";
+      this.description = "AES candidate from TecApro built on a key-as-program design: the user key derives a large internal key of per-round substitution and permutation tables, and the round function is a short fixed byte sequence driven entirely by those tables. 128-bit block, 128/192/256-bit keys, 8 rounds.";
+      this.inventor = "Dianelos Georgoudis, Damian Leroux, Billy Simon Chaves";
+      this.year = 1998;
+      this.category = CategoryType.BLOCK;
+      this.subCategory = "Block Cipher";
+      this.securityStatus = SecurityStatus.INSECURE;
+      this.complexity = ComplexityType.ADVANCED;
+      this.country = CountryCode.CR;
 
-    this.name = "FROG";
-    this.description = "Educational implementation of the FROG block cipher, an AES candidate from TecApro that uses a unique key-as-program design with 8 rounds and complex key schedule.";
-    this.inventor = "Georgoudis, Leroux and Chaves";
-    this.year = 1998;
-    this.category = CategoryType.BLOCK;
-    this.subCategory = "Block Cipher";
-    this.securityStatus = SecurityStatus.INSECURE;
-    this.complexity = ComplexityType.INTERMEDIATE;
-    this.country = CountryCode.CR;
+      this.SupportedKeySizes = [new KeySize(16, 32, 8)];
+      this.SupportedBlockSizes = [new KeySize(16, 16, 1)];
 
-    this.SupportedKeySizes = [new KeySize(16, 32, 8)];
-    this.SupportedBlockSizes = [new KeySize(16, 16, 1)];
+      this.documentation = [
+        new LinkItem("The FROG Encryption Algorithm (TecApro AES submission)", "https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Algorithm-Validation-Program/documents/aes-development/frog.pdf"),
+        new LinkItem("FROG AES Submission (NESSIE mirror)", "https://www.cosic.esat.kuleuven.be/nessie/workshop/submissions/frog.pdf"),
+        new LinkItem("FROG (Wikipedia)", "https://en.wikipedia.org/wiki/FROG")
+      ];
 
-    this.documentation = [
-      new LinkItem("FROG AES Submission", "https://www.cosic.esat.kuleuven.be/nessie/workshop/submissions/frog.pdf")
-    ];
+      this.references = [
+        new LinkItem("A Million Random Digits with 100,000 Normal Deviates (RAND, 1955)", "https://www.rand.org/pubs/monograph_reports/MR1418.html"),
+        new LinkItem("Cryptanalysis of FROG (Wagner, Ferguson, Schneier)", "https://www.schneier.com/academic/archives/1999/01/cryptanalysis_of_fro.html")
+      ];
 
-    this.references = [
-      new LinkItem("Brian Gladman FROG C Reference (Applied Cryptography source code archive)", "https://www.schneier.com/books/applied-cryptography-source/"),
-      new LinkItem("embeddedsw.net libObfuscate FROG Implementation", "https://embeddedsw.net/Cipher_Reference_Home.html")
-    ];
+      this.knownVulnerabilities = [
+        new Vulnerability("Weak key classes and chosen-plaintext attacks", "Wagner, Ferguson and Schneier found large weak-key classes and both chosen-plaintext and chosen-ciphertext attacks; FROG was not selected as an AES finalist.", "Use AES or another vetted cipher.")
+      ];
 
-    this.tests = [
-      {
-        text: "FROG Test Vector 1",
-        uri: "Educational test vector for FROG cipher",
-        input: OpCodes.Hex8ToBytes('00112233445566778899AABBCCDDEEFF'),
-        key: OpCodes.Hex8ToBytes('0F0E0D0C0B0A09080706050403020100'),
-        expected: OpCodes.Hex8ToBytes('63EE65DF98CD8D545305692BB983A3BF')
-      }
-    ];
+      // Known Answer Test vectors from the AES submission's own ecb_vk.txt and
+      // ecb_vt.txt, produced by the submitted reference implementation.
+      //
+      // BYTE ORDER: FROG numbers a block from the least significant byte up, so
+      // index 0 is the LAST byte the AES KAT files print. Every key, plaintext
+      // and ciphertext below is therefore the byte-REVERSAL of the string in the
+      // KAT file: the file's "KEY=800000...00" is the 16-byte array
+      // 00...00,0x80, and so on. They are written here in array order because
+      // that is the order this interface consumes and emits.
+      //
+      // The last three are cross-checks against the FROG shipped in the DarkCrypt
+      // Total Commander plugin, an independent implementation of the same
+      // construction; they are order-agnostic in the sense that they are quoted
+      // exactly as that plugin produces them.
+      this.tests = [
+        {
+          text: "AES KAT ecb_vk.txt I=1 — 128-bit key, single key bit set",
+          uri: "https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Algorithm-Validation-Program/documents/aes-development/frog.pdf",
+          input: OpCodes.Hex8ToBytes('00000000000000000000000000000000'),
+          key: OpCodes.Hex8ToBytes('00000000000000000000000000000080'),
+          expected: OpCodes.Hex8ToBytes('1e1a2a532de59da7e230cc718ad2cb6c')
+        },
+        {
+          text: "AES KAT ecb_vk.txt I=128 — 128-bit key, lowest key bit set",
+          uri: "https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Algorithm-Validation-Program/documents/aes-development/frog.pdf",
+          input: OpCodes.Hex8ToBytes('00000000000000000000000000000000'),
+          key: OpCodes.Hex8ToBytes('01000000000000000000000000000000'),
+          expected: OpCodes.Hex8ToBytes('4f43f3edeb7c2a85d1d8577e0c7378c4')
+        },
+        {
+          text: "AES KAT ecb_vt.txt I=1 — 128-bit key, single plaintext bit set",
+          uri: "https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Algorithm-Validation-Program/documents/aes-development/frog.pdf",
+          input: OpCodes.Hex8ToBytes('00000000000000000000000000000080'),
+          key: OpCodes.Hex8ToBytes('00000000000000000000000000000000'),
+          expected: OpCodes.Hex8ToBytes('82700ab3533100fcd02de6bd6988af43')
+        },
+        {
+          text: "AES KAT ecb_vt.txt I=128 — 128-bit key, lowest plaintext bit set",
+          uri: "https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Algorithm-Validation-Program/documents/aes-development/frog.pdf",
+          input: OpCodes.Hex8ToBytes('01000000000000000000000000000000'),
+          key: OpCodes.Hex8ToBytes('00000000000000000000000000000000'),
+          expected: OpCodes.Hex8ToBytes('b46122f040782cb0cd24ce55e92554c7')
+        },
+        {
+          text: "AES KAT — all-zero 128-bit key and plaintext (order-independent)",
+          uri: "https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Algorithm-Validation-Program/documents/aes-development/frog.pdf",
+          input: OpCodes.Hex8ToBytes('00000000000000000000000000000000'),
+          key: OpCodes.Hex8ToBytes('00000000000000000000000000000000'),
+          expected: OpCodes.Hex8ToBytes('ce0f0611ec5ea12607d4bb435b58f0bf')
+        },
+        {
+          text: "AES KAT ecb_vk.txt I=1 — 192-bit key",
+          uri: "https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Algorithm-Validation-Program/documents/aes-development/frog.pdf",
+          input: OpCodes.Hex8ToBytes('00000000000000000000000000000000'),
+          key: OpCodes.Hex8ToBytes('000000000000000000000000000000000000000000000080'),
+          expected: OpCodes.Hex8ToBytes('d97ec798d02b23e20070c69753f4770e')
+        },
+        {
+          text: "AES KAT ecb_vk.txt I=1 — 256-bit key",
+          uri: "https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Algorithm-Validation-Program/documents/aes-development/frog.pdf",
+          input: OpCodes.Hex8ToBytes('00000000000000000000000000000000'),
+          key: OpCodes.Hex8ToBytes('0000000000000000000000000000000000000000000000000000000000000080'),
+          expected: OpCodes.Hex8ToBytes('e100a4921e34bc89b9c6182b42c6b4b3')
+        },
+        {
+          text: "FROG-256 — zero key and plaintext, cross-checked against the DarkCrypt plugin",
+          uri: "https://totalcmd.net/plugring/darkcrypttc.html",
+          input: OpCodes.Hex8ToBytes('00000000000000000000000000000000'),
+          key: OpCodes.Hex8ToBytes('0000000000000000000000000000000000000000000000000000000000000000'),
+          expected: OpCodes.Hex8ToBytes('b57897cc533074f1a543bf69b65c7bbc')
+        },
+        {
+          text: "FROG-256 — incrementing key and plaintext, cross-checked against the DarkCrypt plugin",
+          uri: "https://totalcmd.net/plugring/darkcrypttc.html",
+          input: OpCodes.Hex8ToBytes('000102030405060708090a0b0c0d0e0f'),
+          key: OpCodes.Hex8ToBytes('000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f'),
+          expected: OpCodes.Hex8ToBytes('2bbb1026a5608ad9bd14ea5064982eb9')
+        },
+        {
+          text: "FROG-256 — shifted incrementing key and plaintext, cross-checked against the DarkCrypt plugin",
+          uri: "https://totalcmd.net/plugring/darkcrypttc.html",
+          input: OpCodes.Hex8ToBytes('101112131415161718191a1b1c1d1e1f'),
+          key: OpCodes.Hex8ToBytes('0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20'),
+          expected: OpCodes.Hex8ToBytes('26fba6a7bbb41616d89c83bd83d97a47')
+        }
+      ];
+    }
+
+    CreateInstance(isInverse = false) {
+      return new FROGInstance(this, isInverse);
+    }
   }
 
-  CreateInstance(isInverse = false) {
-    return new FROGInstance(this, isInverse);
-  }
-}
-
-class FROGInstance extends IBlockCipherInstance {
-  constructor(algorithm, isInverse = false) {
-    super(algorithm);
-    this.isInverse = isInverse;
-    this.inputBuffer = [];
-    this._key = null;
-    this._internalKey = null;
-    this._keySize = 0;
-  }
-
-  set key(keyBytes) {
-    if (!keyBytes) {
+  class FROGInstance extends IBlockCipherInstance {
+    constructor(algorithm, isInverse = false) {
+      super(algorithm);
+      this.isInverse = isInverse;
+      this.inputBuffer = [];
       this._key = null;
-      this._internalKey = null;
-      return;
+      this._roundKeys = null;
+      this.BlockSize = BLOCK_LEN;
+      this.KeySize = 0;
     }
 
-    const isValidSize = this.algorithm.SupportedKeySizes.some(ks =>
-      keyBytes.length >= ks.minSize && keyBytes.length <= ks.maxSize
-    );
-
-    if (!isValidSize) {
-      throw new Error(`Invalid key size: ${keyBytes.length} bytes`);
-    }
-
-    this._key = [...keyBytes];
-    this._setupKey(keyBytes);
-  }
-
-  get key() { return this._key ? [...this._key] : null; }
-
-  Feed(data) {
-    if (!data || data.length === 0) return;
-    if (!this._key) throw new Error("Key not set");
-    for (let _i = 0; _i < data.length; _i++) this.inputBuffer.push(data[_i]);
-  }
-
-  Result() {
-    if (!this._key) throw new Error("Key not set");
-    if (this.inputBuffer.length === 0) throw new Error("No data fed");
-
-    const output = [];
-    const blockSize = 16;
-
-    for (let i = 0; i < this.inputBuffer.length; i += blockSize) {
-      const block = this.inputBuffer.slice(i, i + blockSize);
-      if (block.length !== blockSize) {
-        throw new Error(`Incomplete block: ${block.length} bytes`);
+    set key(keyBytes) {
+      if (!keyBytes) {
+        this._key = null;
+        this._roundKeys = null;
+        this.KeySize = 0;
+        return;
       }
 
-      const processedBlock = this.isInverse ?
-        this._decryptBlock(block) :
-        this._encryptBlock(block);
+      const isValidSize = this.algorithm.SupportedKeySizes.some(ks =>
+        keyBytes.length >= ks.minSize && keyBytes.length <= ks.maxSize
+        && (ks.stepSize === 0 || (keyBytes.length - ks.minSize) % ks.stepSize === 0)
+      );
 
-      for (let _i = 0; _i < processedBlock.length; _i++) output.push(processedBlock[_i]);
-    }
-
-    this.inputBuffer = [];
-    return output;
-  }
-
-  _setupKey(key) {
-    this._keySize = key.length;
-    this._internalKey = new Uint8Array(2304);
-
-    const expandedKey = new Uint8Array(256);
-    for (let i = 0; i < 256; i++) {
-      expandedKey[i] = OpCodes.XorN(key[i % key.length], i);
-    }
-
-    let keyIndex = 0;
-    for (let i = 0; i < 2304; i++) {
-      this._internalKey[i] = expandedKey[keyIndex];
-      keyIndex = (keyIndex + 1) % 256;
-
-      if (i > 0) {
-        this._internalKey[i] = OpCodes.XorN(this._internalKey[i], this._internalKey[i - 1]);
+      if (!isValidSize) {
+        throw new Error(`Invalid key size: ${keyBytes.length} bytes`);
       }
 
-      this._internalKey[i] = OpCodes.RotL8(this._internalKey[i], (i % 8) + 1);
-    }
-  }
-
-  _encryptBlock(data) {
-    if (!this._internalKey) {
-      throw new Error('Key not set up');
+      this._key = [...keyBytes];
+      this.KeySize = keyBytes.length;
+      // The internal key differs between the two directions: decryption needs
+      // each round's substPermu replaced by its inverse.
+      this._roundKeys = generateKeys(this._key, BLOCK_LEN, ROUNDS, this.isInverse);
     }
 
-    const block = new Uint8Array(data);
-    let keyOffset = 0;
+    get key() { return this._key ? [...this._key] : null; }
 
-    for (let round = 0; round < 8; round++) {
-      // Save original block values for operation 2 dependencies
-      const originalBlock = new Uint8Array(block);
+    Feed(data) {
+      if (!data || data.length === 0) return;
+      if (!this._key) throw new Error("Key not set");
+      for (let _i = 0; _i < data.length; _i++) this.inputBuffer.push(data[_i]);
+    }
 
-      for (let i = 0; i < 16; i++) {
-        const instruction = this._internalKey[keyOffset + i];
-        const operation = OpCodes.AndN(instruction, 0x03);
-        const sourceIdx = OpCodes.AndN(OpCodes.Shr32(instruction, 2), 0x0F);
+    Result() {
+      if (!this._key) throw new Error("Key not set");
+      if (this.inputBuffer.length === 0) throw new Error("No data fed");
+      if (this.inputBuffer.length % BLOCK_LEN !== 0)
+        throw new Error(`Input length must be a multiple of ${BLOCK_LEN} bytes`);
 
-        switch (operation) {
-          case 0:
-            block[i] = OpCodes.XorN(block[i], this._internalKey[keyOffset + 16 + sourceIdx]);
-            break;
-          case 1:
-            block[i] = OpCodes.RotL8(block[i], (OpCodes.AndN(sourceIdx, 0x07)) + 1);
-            break;
-          case 2:
-            block[i] = OpCodes.XorN(block[i], originalBlock[sourceIdx % 16]);
-            break;
-          case 3:
-            block[i] = this._substituteByte(block[i], keyOffset + sourceIdx);
-            break;
-        }
+      const output = [];
+      for (let i = 0; i < this.inputBuffer.length; i += BLOCK_LEN) {
+        const state = this.inputBuffer.slice(i, i + BLOCK_LEN);
+        if (this.isInverse) frogDecrypt(state, this._roundKeys);
+        else frogEncrypt(state, this._roundKeys);
+        for (let _i = 0; _i < state.length; _i++) output.push(state[_i]);
       }
 
-      this._mixColumns(block);
-      keyOffset += 288;
-    }
-
-    return block;
-  }
-
-  _decryptBlock(data) {
-    if (!this._internalKey) {
-      throw new Error('Key not set up');
-    }
-
-    const block = new Uint8Array(data);
-    let keyOffset = 288 * 7;
-
-    for (let round = 7; round >= 0; round--) {
-      this._invMixColumns(block);
-
-      // Save original block values for operation 2 dependencies
-      const originalBlock = new Uint8Array(block);
-
-      for (let i = 15; i >= 0; i--) {
-        const instruction = this._internalKey[keyOffset + i];
-        const operation = OpCodes.AndN(instruction, 0x03);
-        const sourceIdx = OpCodes.AndN(OpCodes.Shr32(instruction, 2), 0x0F);
-
-        switch (operation) {
-          case 0:
-            block[i] = OpCodes.XorN(block[i], this._internalKey[keyOffset + 16 + sourceIdx]);
-            break;
-          case 1:
-            block[i] = OpCodes.RotR8(block[i], (OpCodes.AndN(sourceIdx, 0x07)) + 1);
-            break;
-          case 2:
-            block[i] = OpCodes.XorN(block[i], originalBlock[sourceIdx % 16]);
-            break;
-          case 3:
-            block[i] = this._invSubstituteByte(block[i], keyOffset + sourceIdx);
-            break;
-        }
-      }
-
-      keyOffset -= 288;
-    }
-
-    return block;
-  }
-
-  _substituteByte(byte, keyOffset) {
-    const sboxKey = this._internalKey[keyOffset % 2304];
-    return OpCodes.AndN(OpCodes.XorN(byte + sboxKey, OpCodes.RotL8(byte, 3)), 0xFF);
-  }
-
-  _invSubstituteByte(byte, keyOffset) {
-    for (let i = 0; i < 256; i++) {
-      if (this._substituteByte(i, keyOffset) === byte) {
-        return i;
-      }
-    }
-    return byte;
-  }
-
-  _mixColumns(block) {
-    for (let col = 0; col < 4; col++) {
-      const offset = col * 4;
-      const temp = [
-        block[offset],
-        block[offset + 1],
-        block[offset + 2],
-        block[offset + 3]
-      ];
-
-      block[offset] = OpCodes.XorN(OpCodes.XorN(temp[1], temp[2]), temp[3]);
-      block[offset + 1] = OpCodes.XorN(OpCodes.XorN(temp[0], temp[2]), temp[3]);
-      block[offset + 2] = OpCodes.XorN(OpCodes.XorN(temp[0], temp[1]), temp[3]);
-      block[offset + 3] = OpCodes.XorN(OpCodes.XorN(temp[0], temp[1]), temp[2]);
+      this.inputBuffer = [];
+      return output;
     }
   }
-
-  _invMixColumns(block) {
-    for (let col = 0; col < 4; col++) {
-      const offset = col * 4;
-      const temp = [
-        block[offset],
-        block[offset + 1],
-        block[offset + 2],
-        block[offset + 3]
-      ];
-
-      block[offset] = OpCodes.XorN(OpCodes.XorN(temp[1], temp[2]), temp[3]);
-      block[offset + 1] = OpCodes.XorN(OpCodes.XorN(temp[0], temp[2]), temp[3]);
-      block[offset + 2] = OpCodes.XorN(OpCodes.XorN(temp[0], temp[1]), temp[3]);
-      block[offset + 3] = OpCodes.XorN(OpCodes.XorN(temp[0], temp[1]), temp[2]);
-    }
-  }
-}
-
 
   // ===== REGISTRATION =====
 

--- a/Cipher/algorithms/block/frog.js
+++ b/Cipher/algorithms/block/frog.js
@@ -121,132 +121,133 @@
   const RANDOM_SEED = buildRandomSeed();
 
   // ===== INTERNAL KEY CONSTRUCTION =====
+  //
+  // The internal key is held as one flat byte array of
+  // (blockLength * 2 + 256) * rounds entries. Round r occupies the window
+  // starting at r * SUBKEY_LEN, laid out as xorBu[blockLength],
+  // substPermu[256], bombPermu[blockLength] - the same order as the tIterKey
+  // record of the reference implementation. The permutation helpers therefore
+  // take a base offset and a length rather than a sub-array.
 
-  // Turns an arbitrary byte array into a permutation of its own index range by a
+  const SUBKEY_LEN = BLOCK_LEN * 2 + 256;
+
+  // Turns an arbitrary byte range into a permutation of its own index range by a
   // key-driven selection sweep: at each step the next unused value is chosen at
   // an offset given by the incoming byte. FROG AES submission, "makePermutation".
-  function makePermutation(input) {
-    const length = input.length;
+  function makePermutation(data, offset, length) {
     const use = new Array(length);
     for (let i = 0; i < length; ++i) use[i] = i;
 
     let index = 0;
     let last = length - 1;
     for (let i = 0; i < length - 1; ++i) {
-      index = (index + input[i]) % (last + 1);
-      input[i] = use[index];
+      index = (index + data[offset + i]) % (last + 1);
+      data[offset + i] = use[index];
       if (index < last) use.splice(index, 1);
       --last;
       if (index > last) index = 0;
     }
-    input[length - 1] = use[0];
+    data[offset + length - 1] = use[0];
   }
 
-  function invertPermutation(permutation) {
-    const inverse = new Array(permutation.length);
-    for (let i = 0; i < permutation.length; ++i) inverse[permutation[i]] = i;
-    for (let i = 0; i < permutation.length; ++i) permutation[i] = inverse[i];
+  function invertPermutation(data, offset, length) {
+    const inverse = new Array(length);
+    for (let i = 0; i < length; ++i) inverse[data[offset + i]] = i;
+    for (let i = 0; i < length; ++i) data[offset + i] = inverse[i];
   }
 
   // Merges any shorter cycles of bombPermu into one full-length cycle, so that
   // every byte position is reachable from every other. FROG AES submission,
   // "make1Cycle". A side effect is that bombPermu[i] is never i, which is what
   // keeps the round function's third step from cancelling its own input.
-  function make1Cycle(bombPermu, blockLength) {
+  function make1Cycle(data, offset, blockLength) {
     const used = new Array(blockLength).fill(0);
     let j = 0;
     for (let i = 0; i < blockLength - 1; ++i) {
-      if (bombPermu[j] === 0) {
+      if (data[offset + j] === 0) {
         let k = j;
         do {
           k = (k + 1) % blockLength;
         } while (used[k] !== 0);
-        bombPermu[j] = k;
+        data[offset + j] = k;
         let l = k;
-        while (bombPermu[l] !== k) l = bombPermu[l];
-        bombPermu[l] = 0;
+        while (data[offset + l] !== k) l = data[offset + l];
+        data[offset + l] = 0;
       }
       used[j] = 1;
-      j = bombPermu[j];
+      j = data[offset + j];
     }
   }
 
   // Stops bombPermu[i] pointing at the byte the round function's second step
   // already XORs, which would otherwise undo it. FROG AES submission,
   // "removeReferences".
-  function removeReferences(bombPermu, blockLength) {
+  function removeReferences(data, offset, blockLength) {
     for (let i = 0; i < blockLength; ++i) {
       const j = (i + 1) % blockLength;
-      if (bombPermu[i] === j) bombPermu[i] = (j + 1) % blockLength;
+      if (data[offset + i] === j) data[offset + i] = (j + 1) % blockLength;
     }
   }
 
-  // Cuts a flat internal-key byte array into one record per round.
-  function toStructuredKey(bytes, blockLength, rounds) {
-    const subkeyLength = bytes.length / rounds;
-    const result = new Array(rounds);
+  function makeInternalKey(bytes, blockLength, rounds) {
     for (let r = 0; r < rounds; ++r) {
-      const offsetXorBu = r * subkeyLength;
-      const offsetSubstPermu = offsetXorBu + blockLength;
-      const offsetBombPermu = offsetSubstPermu + 256;
-      result[r] = {
-        xorBu: bytes.slice(offsetXorBu, offsetSubstPermu),
-        substPermu: bytes.slice(offsetSubstPermu, offsetBombPermu),
-        bombPermu: bytes.slice(offsetBombPermu, offsetBombPermu + blockLength)
-      };
+      const substAt = r * SUBKEY_LEN + blockLength;
+      const bombAt = substAt + 256;
+      makePermutation(bytes, substAt, 256);
+      makePermutation(bytes, bombAt, blockLength);
+      make1Cycle(bytes, bombAt, blockLength);
+      removeReferences(bytes, bombAt, blockLength);
     }
-    return result;
+    return bytes;
   }
 
-  function makeInternalKey(bytes, blockLength, rounds, invert) {
-    const structuredKey = toStructuredKey(bytes, blockLength, rounds);
-    for (let r = 0; r < rounds; ++r) {
-      const record = structuredKey[r];
-      makePermutation(record.substPermu);
-      if (invert) invertPermutation(record.substPermu);
-      makePermutation(record.bombPermu);
-      make1Cycle(record.bombPermu, blockLength);
-      removeReferences(record.bombPermu, blockLength);
-    }
-    return structuredKey;
+  // Replaces every round's substPermu by its inverse, which is the only
+  // difference between the encryption and the decryption internal key.
+  function invertSubstitutions(internalKey, blockLength, rounds) {
+    for (let r = 0; r < rounds; ++r)
+      invertPermutation(internalKey, r * SUBKEY_LEN + blockLength, 256);
   }
 
   // ===== BLOCK TRANSFORM =====
 
-  function frogEncrypt(state, roundKeys) {
-    for (let r = 0; r < roundKeys.length; ++r) {
-      const record = roundKeys[r];
-      for (let i = 0; i < state.length; ++i) {
-        state[i] = record.substPermu[OpCodes.XorN(state[i], record.xorBu[i])];
-        state[(i + 1) % state.length] ^= state[i];
-        state[record.bombPermu[i]] ^= state[i];
+  function frogEncrypt(state, internalKey, blockLength, rounds) {
+    for (let r = 0; r < rounds; ++r) {
+      const xorAt = r * SUBKEY_LEN;
+      const substAt = xorAt + blockLength;
+      const bombAt = substAt + 256;
+      for (let i = 0; i < blockLength; ++i) {
+        state[i] = internalKey[substAt + OpCodes.XorN(state[i], internalKey[xorAt + i])];
+        state[(i + 1) % blockLength] ^= state[i];
+        state[internalKey[bombAt + i]] ^= state[i];
       }
     }
   }
 
-  function frogDecrypt(state, roundKeys) {
-    for (let r = roundKeys.length - 1; r >= 0; --r) {
-      const record = roundKeys[r];
-      for (let i = state.length - 1; i >= 0; --i) {
-        state[record.bombPermu[i]] ^= state[i];
-        state[(i + 1) % state.length] ^= state[i];
-        state[i] = OpCodes.XorN(record.substPermu[state[i]], record.xorBu[i]);
+  function frogDecrypt(state, internalKey, blockLength, rounds) {
+    for (let r = rounds - 1; r >= 0; --r) {
+      const xorAt = r * SUBKEY_LEN;
+      const substAt = xorAt + blockLength;
+      const bombAt = substAt + 256;
+      for (let i = blockLength - 1; i >= 0; --i) {
+        state[internalKey[bombAt + i]] ^= state[i];
+        state[(i + 1) % blockLength] ^= state[i];
+        state[i] = OpCodes.XorN(internalKey[substAt + state[i]], internalKey[xorAt + i]);
       }
     }
   }
 
   // ===== KEY SCHEDULE =====
 
-  function generateKeys(keyBytes, blockLength, rounds, invert) {
+  function generateKeys(keyBytes, blockLength, rounds) {
     const keyLength = keyBytes.length;
-    const internalKeyLength = (blockLength * 2 + 256) * rounds;
+    const internalKeyLength = SUBKEY_LEN * rounds;
 
     const simpleKey = new Array(internalKeyLength);
     for (let i = 0; i < internalKeyLength; ++i) {
       simpleKey[i] = OpCodes.XorN(RANDOM_SEED[i % 251], keyBytes[i % keyLength]);
     }
 
-    const intermediateKey = makeInternalKey(simpleKey, blockLength, rounds, false);
+    const intermediateKey = makeInternalKey(simpleKey, blockLength, rounds);
 
     // Self-keying pass: an IV derived from the user key is encrypted over and
     // over under the intermediate internal key, OFB fashion, and the output
@@ -259,13 +260,13 @@
     const material = new Array(internalKeyLength);
     let filled = 0;
     while (filled < internalKeyLength) {
-      frogEncrypt(iv, intermediateKey);
+      frogEncrypt(iv, intermediateKey, blockLength, rounds);
       const chunk = Math.min(blockLength, internalKeyLength - filled);
       for (let j = 0; j < chunk; ++j) material[filled + j] = iv[j];
       filled += chunk;
     }
 
-    return makeInternalKey(material, blockLength, rounds, invert);
+    return makeInternalKey(material, blockLength, rounds);
   }
 
   // ===== ALGORITHM IMPLEMENTATION =====
@@ -427,7 +428,8 @@
       this.KeySize = keyBytes.length;
       // The internal key differs between the two directions: decryption needs
       // each round's substPermu replaced by its inverse.
-      this._roundKeys = generateKeys(this._key, BLOCK_LEN, ROUNDS, this.isInverse);
+      this._roundKeys = generateKeys(this._key, BLOCK_LEN, ROUNDS);
+      if (this.isInverse) invertSubstitutions(this._roundKeys, BLOCK_LEN, ROUNDS);
     }
 
     get key() { return this._key ? [...this._key] : null; }
@@ -447,8 +449,8 @@
       const output = [];
       for (let i = 0; i < this.inputBuffer.length; i += BLOCK_LEN) {
         const state = this.inputBuffer.slice(i, i + BLOCK_LEN);
-        if (this.isInverse) frogDecrypt(state, this._roundKeys);
-        else frogEncrypt(state, this._roundKeys);
+        if (this.isInverse) frogDecrypt(state, this._roundKeys, BLOCK_LEN, ROUNDS);
+        else frogEncrypt(state, this._roundKeys, BLOCK_LEN, ROUNDS);
         for (let _i = 0; _i < state.length; _i++) output.push(state[_i]);
       }
 

--- a/Cipher/algorithms/block/hpc.js
+++ b/Cipher/algorithms/block/hpc.js
@@ -108,6 +108,13 @@
     0x158D9554F7B46BCEn - 9n,   0xA784D9045190CFEFn - 3n
   ];
 
+  // Nibble permutations used by the Tiny cipher's 4-, 5- and 6-bit paths. Each
+  // constant packs a permutation of 0..15 as sixteen nibbles, so the image of v
+  // is nibble v: (PERMn >> (v * 4)) & 15. PERM1I/PERM2I are the exact inverses,
+  // which is what fixes the indexing convention: the shift amount is (v & 15)
+  // scaled by four, NOT v masked with (15 << 2). The latter reaches only shift
+  // amounts 0, 4, 8 and 12, i.e. four of the sixteen nibbles, collapsing the
+  // "permutation" into a four-to-one map and destroying the block's contents.
   const PERM1 = 0x324f6a850d19e7cbn;
   const PERM2 = 0x2b7e1568adf09c43n;
   const PERM1I = 0xc3610a492b8dfe57n;
@@ -186,8 +193,11 @@
       }
     }
 
-    // Handle partial last word for non-512-bit blocks
-    if (bitSize < 512 && byteIdx < byteLimit) {
+    // Handle the trailing word. The loop above deliberately stops on a whole-word
+    // boundary below byteLimit, so the final word always lands here - including
+    // the 512-bit case, where the eighth word is the trailing one and was
+    // previously skipped outright, silently zeroing the top 64 bits of the block.
+    if (byteIdx < byteLimit) {
       const lastWordIdx = Math.min(wordCount - 1, Math.floor((bitSize + 63) / 64) - 1);
       for (let b = 0; b < 8 && byteIdx < byteLimit; ++b, ++byteIdx) {
         state[lastWordIdx] |= OpCodes.ShiftLn(BigInt(bytes[byteIdx] || 0), BigInt(b * 8));
@@ -211,7 +221,11 @@
     const byteLimit = bitSize <= 512 ? Math.ceil(bitSize / 8) : 64;
     const bytes = new Array(byteLimit).fill(0);
     const wordLimit = OpCodes.AndN((byteLimit - 1), ~7);
-    const lastWord64 = bitSize <= 64 ? 1 : (bitSize <= 128 ? 2 : HPC_ROUND_COUNT);
+    // Index (plus one) of the word holding the trailing bytes. This must be the
+    // block's own last word, not word 7: packBytesToState writes the trailing
+    // bytes to ceil(bitSize/64)-1, so hardcoding 7 for every block wider than
+    // 128 bits read the tail back out of a word the block never occupied.
+    const lastWord64 = Math.min(HPC_ROUND_COUNT, Math.ceil(bitSize / 64));
 
     let byteIdx = 0;
     for (let w = 0; w < HPC_ROUND_COUNT && byteIdx < wordLimit; ++w) {
@@ -362,9 +376,9 @@
           for (let bi = 0; bi < 64; bi += 8) {
             s0 = mask64(OpCodes.XorN(s0, t));
             t = OpCodes.ShiftRn(t, 4n);
-            s0 = (OpCodes.AndN((OpCodes.ShiftRn(PERM1, (s0&OpCodes.ShiftLn(15n, 2n)))), 15n));
+            s0 = (OpCodes.AndN((OpCodes.ShiftRn(PERM1, OpCodes.ShiftLn(OpCodes.AndN(s0, 15n), 2n))), 15n));
             s0 = mask64(s0 + t);
-            s0 = (OpCodes.AndN((OpCodes.ShiftRn(PERM2, (s0&OpCodes.ShiftLn(15n, 2n)))), 15n));
+            s0 = (OpCodes.AndN((OpCodes.ShiftRn(PERM2, OpCodes.ShiftLn(OpCodes.AndN(s0, 15n), 2n))), 15n));
             t = OpCodes.ShiftRn(t, 4n);
           }
         }
@@ -395,11 +409,11 @@
         let t = tmp[ri];
         for (let bi = 0; bi < (7 - (blockSize - 5)); ++bi) {
           s0 = mask64(OpCodes.XorN(s0, t));
-          s0 = (OpCodes.AndN(s0, pmask))|((OpCodes.AndN((OpCodes.ShiftRn(PERM1, (s0&OpCodes.ShiftLn(15n, 2n)))), 15n)));
+          s0 = (OpCodes.AndN(s0, pmask))|((OpCodes.AndN((OpCodes.ShiftRn(PERM1, OpCodes.ShiftLn(OpCodes.AndN(s0, 15n), 2n))), 15n)));
           s0 = mask64(OpCodes.XorN(s0, ((OpCodes.ShiftRn(s0, 3n)))));
           t = OpCodes.ShiftRn(t, BigInt(blockSize));
           s0 = mask64(s0 + t);
-          s0 = (OpCodes.AndN(s0, pmask))|((OpCodes.AndN((OpCodes.ShiftRn(PERM2, (s0&OpCodes.ShiftLn(15n, 2n)))), 15n)));
+          s0 = (OpCodes.AndN(s0, pmask))|((OpCodes.AndN((OpCodes.ShiftRn(PERM2, OpCodes.ShiftLn(OpCodes.AndN(s0, 15n), 2n))), 15n)));
           t = OpCodes.ShiftRn(t, BigInt(blockSize - 1));
         }
       }
@@ -495,9 +509,9 @@
           const t = tmp[ri];
           for (let bi = 64; bi > 0; bi -= 8) {
             const v = OpCodes.AndN((OpCodes.ShiftRn(t, BigInt(bi - 8))), 0xFFn);
-            s0 = (OpCodes.AndN((OpCodes.ShiftRn(PERM2I, (s0&OpCodes.ShiftLn(15n, 2n)))), 15n));
+            s0 = (OpCodes.AndN((OpCodes.ShiftRn(PERM2I, OpCodes.ShiftLn(OpCodes.AndN(s0, 15n), 2n))), 15n));
             s0 = mask64(s0 - ((OpCodes.ShiftRn(v, 4n))));
-            s0 = (OpCodes.AndN((OpCodes.ShiftRn(PERM1I, (s0&OpCodes.ShiftLn(15n, 2n)))), 15n));
+            s0 = (OpCodes.AndN((OpCodes.ShiftRn(PERM1I, OpCodes.ShiftLn(OpCodes.AndN(s0, 15n), 2n))), 15n));
             s0 = mask64(OpCodes.XorN(s0, v));
           }
         }
@@ -526,11 +540,17 @@
       for (let ri = (OpCodes.Shr32(tmpBs, 6)); ri-- > 0; ) {
         const t = tmp[ri];
         for (let bi = (7 - (blockSize - 5)); bi-- > 0; ) {
-          const v = OpCodes.AndN((OpCodes.ShiftRn(t, BigInt(bi * ((OpCodes.Shl32(blockSize, 1)) - 1)))), ((OpCodes.ShiftLn(1n, BigInt((OpCodes.Shl32(blockSize, 1)) - 1))) - 1n));
-          s0 = (OpCodes.AndN(s0, pmask))|((OpCodes.AndN((OpCodes.ShiftRn(PERM2I, (s0&OpCodes.ShiftLn(15n, 2n)))), 15n)));
+          // Each forward iteration advances t by blockSize + (blockSize - 1)
+          // bits but READS 2*blockSize of them: blockSize for the XOR and the
+          // next blockSize for the addition, so successive iterations overlap by
+          // one bit. Recovering only (2*blockSize - 1) bits here - the stride
+          // rather than the span - dropped the top bit of the addend, which is
+          // inside the block mask and therefore changes the result.
+          const v = OpCodes.AndN((OpCodes.ShiftRn(t, BigInt(bi * ((OpCodes.Shl32(blockSize, 1)) - 1)))), ((OpCodes.ShiftLn(1n, BigInt(OpCodes.Shl32(blockSize, 1)))) - 1n));
+          s0 = (OpCodes.AndN(s0, pmask))|((OpCodes.AndN((OpCodes.ShiftRn(PERM2I, OpCodes.ShiftLn(OpCodes.AndN(s0, 15n), 2n))), 15n)));
           s0 = mask64(s0 - (OpCodes.ShiftRn(v, BigInt(blockSize))));
           s0 = mask64(OpCodes.XorN(s0, (OpCodes.ShiftRn((OpCodes.AndN(s0, mask)), 3n))));
-          s0 = (OpCodes.AndN(s0, pmask))|((OpCodes.AndN((OpCodes.ShiftRn(PERM1I, (s0&OpCodes.ShiftLn(15n, 2n)))), 15n)));
+          s0 = (OpCodes.AndN(s0, pmask))|((OpCodes.AndN((OpCodes.ShiftRn(PERM1I, OpCodes.ShiftLn(OpCodes.AndN(s0, 15n), 2n))), 15n)));
           s0 = mask64(OpCodes.XorN(s0, v));
         }
       }
@@ -808,8 +828,17 @@
   // ========================[ LONG CIPHER (129-512 bits) ]========================
 
   function longEncrypt(state, spice, KX, blockSize, mask, backup) {
+    // The Long cipher (HPC spec, "Long Cipher", 129-512 bit blocks) keeps the
+    // block's FIRST two words in s0/s1, its LAST word in s7, and the words in
+    // between in s2..s6 - which is why s7 is the one masked with lmask and why
+    // the cascade below brings s2..s6 into play as the block crosses 192, 256,
+    // 320, 384 and 448 bits (one extra intermediate word per step). Binding s7
+    // to state[7] instead of to the block's own last word left the last word
+    // untouched and carried a word of state that the output never recorded, so
+    // every block narrower than 449 bits was undecryptable.
+    const lastWord = Math.ceil(blockSize / 64) - 1;
     let s0 = state[0], s1 = state[1], s2 = state[2], s3 = state[3];
-    let s4 = state[4], s5 = state[5], s6 = state[6], s7 = state[7];
+    let s4 = state[4], s5 = state[5], s6 = state[6], s7 = state[lastWord];
 
     for (let ri = 0; ri < HPC_ROUND_COUNT; ++ri) {
       let t = OpCodes.AndN(s0, 0xFFn);
@@ -887,12 +916,14 @@
     }
 
     state[0] = s0; state[1] = s1; state[2] = s2; state[3] = s3;
-    state[4] = s4; state[5] = s5; state[6] = s6; state[7] = s7;
+    state[4] = s4; state[5] = s5; state[6] = s6;
+    state[lastWord] = s7; // written last: for narrow blocks it overlaps an s2..s6 slot
   }
 
   function longDecrypt(state, spice, KX, blockSize, mask, backup) {
+    const lastWord = Math.ceil(blockSize / 64) - 1;
     let s0 = state[0], s1 = state[1], s2 = state[2], s3 = state[3];
-    let s4 = state[4], s5 = state[5], s6 = state[6], s7 = state[7];
+    let s4 = state[4], s5 = state[5], s6 = state[6], s7 = state[lastWord];
 
     for (let ri = HPC_ROUND_COUNT; ri-- > 0; ) {
       let t, k, kk;
@@ -977,7 +1008,8 @@
     }
 
     state[0] = s0; state[1] = s1; state[2] = s2; state[3] = s3;
-    state[4] = s4; state[5] = s5; state[6] = s6; state[7] = s7;
+    state[4] = s4; state[5] = s5; state[6] = s6;
+    state[lastWord] = s7;
   }
 
   // ========================[ EXTENDED STIR (for Extended cipher) ]========================
@@ -1529,11 +1561,26 @@
         throw new Error("No data fed");
       }
 
-      // Determine block size in bits
+      // Determine block size in bits. HPC encrypts exactly one block per call,
+      // so when a block size has been declared the input has to BE that block:
+      // it is neither padded nor split. Silently keeping the first ceil(bits/8)
+      // bytes and dropping the rest - and dropping the bits above the block
+      // width in the trailing byte - turned a caller's mistake into quiet data
+      // loss, so both are refused instead.
       let blockSizeBits = this._blockSizeBits;
       if (!blockSizeBits) {
         // Default to input size in bits
         blockSizeBits = this.inputBuffer.length * 8;
+      } else {
+        const blockBytes = Math.ceil(blockSizeBits / 8);
+        if (this.inputBuffer.length !== blockBytes)
+          throw new Error("Input must be exactly one " + blockSizeBits + "-bit block ("
+            + blockBytes + " bytes); got " + this.inputBuffer.length);
+        const usedBitsInLastByte = blockSizeBits - (blockBytes - 1) * 8;
+        if (OpCodes.Shr32(this.inputBuffer[blockBytes - 1], usedBitsInLastByte) !== 0)
+          throw new Error("Input carries bits above the declared " + blockSizeBits
+            + "-bit block width; byte " + (blockBytes - 1) + " must fit in "
+            + usedBitsInLastByte + " bit(s)");
       }
 
       const cipherId = getCipherId(blockSizeBits);
@@ -1563,6 +1610,11 @@
       // Calculate mask for last word
       const mask = (OpCodes.ShiftLn(((OpCodes.ShiftLn(1n, BigInt((blockSizeBits - 1) % 64))) - 1n), 1n))|1n;
       const backup = 0;
+
+      // Streamed body of an Extended block (words 8 and up). The block's first
+      // eight words never leave the state registers, so this buffer is only
+      // complete once they are written back over its first 64 bytes below.
+      let extendedBuffer = null;
 
       // Encryption and decryption have different KX addition/subtraction order
       if (!this.isInverse) {
@@ -1596,11 +1648,13 @@
               longEncrypt(state, spice, this._KX[cipherId - 1], blockSizeBits, mask, backup);
               break;
             case CIPHER_ID_EXTENDED:
-              const plaintext = this.inputBuffer;
-              const ciphertext = new Array(this.inputBuffer.length).fill(0);
-              extendedEncrypt(state, spice, this._KX[cipherId - 1], plaintext, ciphertext, blockSizeBits, mask, backup);
-              this.inputBuffer = [];
-              return ciphertext;
+              // Falls through to the post-KX step like every other sub-cipher.
+              // Returning here skipped it entirely, so an Extended block was
+              // encrypted with the pre-KX whitening only and decrypted with the
+              // post-KX whitening only - two different transforms.
+              extendedBuffer = new Array(this.inputBuffer.length).fill(0);
+              extendedEncrypt(state, spice, this._KX[cipherId - 1], this.inputBuffer, extendedBuffer, blockSizeBits, mask, backup);
+              break;
           }
 
           // Add post-KX
@@ -1645,11 +1699,9 @@
               longDecrypt(state, spice, this._KX[cipherId - 1], blockSizeBits, mask, backup);
               break;
             case CIPHER_ID_EXTENDED:
-              const ciphertext = this.inputBuffer;
-              const plaintext = new Array(this.inputBuffer.length).fill(0);
-              extendedDecrypt(state, spice, this._KX[cipherId - 1], ciphertext, plaintext, blockSizeBits, mask, backup);
-              this.inputBuffer = [];
-              return plaintext;
+              extendedBuffer = new Array(this.inputBuffer.length).fill(0);
+              extendedDecrypt(state, spice, this._KX[cipherId - 1], this.inputBuffer, extendedBuffer, blockSizeBits, mask, backup);
+              break;
           }
 
           // Subtract pre-KX (which was added BEFORE encryption)
@@ -1670,6 +1722,18 @@
 
       // Unpack state to output
       const output = unpackStateToBytes(state, blockSizeBits);
+
+      // The Extended cipher holds the block's first eight words in the state
+      // registers for the whole transform and streams only words 8 and up
+      // through the buffer, so the head has to be written back over the
+      // buffer's leading 64 bytes. Without it those bytes stayed as the zeros
+      // the buffer was allocated with, which is why an Extended block came back
+      // from decryption as a run of nulls.
+      if (extendedBuffer) {
+        for (let i = 0; i < output.length && i < extendedBuffer.length; ++i) extendedBuffer[i] = output[i];
+        this.inputBuffer = [];
+        return extendedBuffer;
+      }
 
       this.inputBuffer = [];
       return output;

--- a/Cipher/algorithms/block/hpc.js
+++ b/Cipher/algorithms/block/hpc.js
@@ -110,9 +110,9 @@
 
   // Nibble permutations used by the Tiny cipher's 4-, 5- and 6-bit paths. Each
   // constant packs a permutation of 0..15 as sixteen nibbles, so the image of v
-  // is nibble v: (PERMn >> (v * 4)) & 15. PERM1I/PERM2I are the exact inverses,
-  // which is what fixes the indexing convention: the shift amount is (v & 15)
-  // scaled by four, NOT v masked with (15 << 2). The latter reaches only shift
+  // is nibble v: SHR(PERMn, v * 4) AND 15. PERM1I/PERM2I are the exact
+  // inverses, which is what fixes the indexing convention: the shift amount is
+  // (v AND 15) scaled by four, NOT v masked with SHL(15, 2), which reaches only
   // amounts 0, 4, 8 and 12, i.e. four of the sixteen nibbles, collapsing the
   // "permutation" into a four-to-one map and destroying the block's contents.
   const PERM1 = 0x324f6a850d19e7cbn;

--- a/Cipher/algorithms/block/sc2000.js
+++ b/Cipher/algorithms/block/sc2000.js
@@ -1,3 +1,45 @@
+/*
+ * SC2000 Implementation
+ * Compatible with AlgorithmFramework
+ * (c)2006-2025 Hawkynt
+ *
+ * SC2000, designed by Takeshi Shimoyama, Hirotaka Yanami, Kazuhiro Yokoyama,
+ * Masahiko Takenaka, Kouichi Itoh, Jun Yajima, Naoya Torii and Hidema Tanaka at
+ * Fujitsu Laboratories. Presented at FSE 2001, submitted to NESSIE and included
+ * in the CRYPTREC recommended ciphers list. 128-bit block, 128/192/256-bit keys.
+ *
+ * The cipher alternates an SPN half-round with a pair of Feistel rounds. Writing
+ * I for the subkey XOR, B for the bit-sliced 4x4 S-box layer and R for one
+ * Feistel round, the structure is (CRYPTREC specification, section 2):
+ *
+ *   128-bit key, "6.5 rounds", 56 extended keys:
+ *     in-I-B-I-R5xR5-I-B-I-R3xR3-I-B-I-R5xR5-I-B-I-R3xR3-I-B-I-R5xR5-I-B-I-R3xR3-I-B-I-out
+ *   192/256-bit key, "7.5 rounds", 64 extended keys: the same with one more
+ *     R5xR5-I-B-I appended.
+ *
+ * R5 and R3 are R with mask 0x55555555 and 0x33333333; there is no per-round
+ * mask table, only those two values. "x" is the cross connection
+ * (a,b,c,d) -> (c,d,a,b) between the two Feistel rounds of a pair.
+ *
+ *   I(a,b,c,d, k0..k3) = (a^k0, b^k1, c^k2, d^k3)
+ *   R(a,b,c,d, mask)   = (a^s, b^t, c, d) where (s,t) = F(c,d,mask)
+ *   F(a,b,mask)        = L(M(S(a)), M(S(b)), mask)
+ *   L(a,b,mask)        = ((a AND mask) ^ b, (b AND NOT mask) ^ a)
+ *   S splits a word MSB-first into 6/5/5/5/5/6-bit fields and runs the outer
+ *     fields through S6 and the inner four through S5.
+ *   M is a 32x32 GF(2) matrix multiply: bit i of the input (bit 0 being the
+ *     most significant) selects row M[i] to be XORed into the accumulator.
+ *   B applies the 4-bit S-box S4 bit-slice fashion across the four state words.
+ *
+ * Decryption reuses I and R unchanged and replaces B by its inverse. R is a
+ * Feistel round, hence an involution, and an RxR pair with the cross connection
+ * is self-inverse as well, so only the subkey order reverses: the extended keys
+ * are consumed in reverse groups of four and the mask sequence runs backwards.
+ *
+ * Words are big-endian throughout, and within a word bit 0 is the most
+ * significant bit.
+ */
+
 (function (root, factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD
@@ -31,286 +73,397 @@
 
   // Extract framework components
   const { RegisterAlgorithm, CategoryType, SecurityStatus, ComplexityType, CountryCode,
-          BlockCipherAlgorithm, IBlockCipherInstance, LinkItem, KeySize } = AlgorithmFramework;
+          BlockCipherAlgorithm, IBlockCipherInstance, LinkItem, Vulnerability, KeySize } = AlgorithmFramework;
+
+  // ===== TABLES (CRYPTREC specification, section 2) =====
+
+  // 6x6 S-box, used for the two outer 6-bit fields of S.
+  const S6 = [
+    47,59,25,42,15,23,28,39,26,38,36,19,60,24,29,56,
+    37,63,20,61,55, 2,30,44, 9,10, 6,22,53,48,51,11,
+    62,52,35,18,14,46, 0,54,17,40,27, 4,31, 8, 5,12,
+     3,16,41,34,33, 7,45,49,50,58, 1,21,43,57,32,13
+  ];
+
+  // 5x5 S-box, used for the four inner 5-bit fields of S.
+  const S5 = [
+    20,26, 7,31,19,12,10,15,22,30,13,14, 4,24, 9,18,
+    27,11, 1,21, 6,16, 2,28,23, 5, 8, 3, 0,17,29,25
+  ];
+
+  // 4x4 S-box for B, and its exact functional inverse for B^-1.
+  const S4 = [2,5,10,12,7,15,1,11,13,6,0,9,4,8,3,14];
+  const S4I = [10,6,0,14,12,1,9,4,13,11,2,7,3,8,15,5];
+
+  // 32x32 GF(2) diffusion matrix for M. Row i is XORed into the accumulator
+  // when bit i of the input - counting bit 0 as the most significant - is set.
+  const MATRIX = [
+    0xD0C19225, 0xA5A2240A, 0x1B84D250, 0xB728A4A1,
+    0x6A704902, 0x85DDDBE6, 0x766FF4A4, 0xECDFE128,
+    0xAFD13E94, 0xDF837D09, 0xBB27FA52, 0x695059AC,
+    0x52A1BB58, 0xCC322F1D, 0x1844565B, 0xB4A8ACF6,
+    0x34235438, 0x6847A851, 0xE48C0CBB, 0xCD181136,
+    0x9A112A0C, 0x43EC6D0E, 0x87D8D27D, 0x487DC995,
+    0x90FB9B4B, 0xA1F63697, 0xFC513ED9, 0x78A37D93,
+    0x8D16C5DF, 0x9E0C8BBE, 0x3C381F7C, 0xE9FB0779
+  ];
+
+  // Extended-key selection tables. For output word n the "Order" row picks which
+  // of the four intermediate branches (a,b,c,d) supplies each of the four
+  // operands, and the "Index" row picks which of that branch's three words.
+  const ORDER = [
+    [0,1,2,3],[1,0,3,2],[2,3,0,1],[3,2,1,0],
+    [0,2,3,1],[1,3,2,0],[2,0,1,3],[3,1,0,2],
+    [0,3,1,2],[1,2,0,3],[2,1,3,0],[3,0,2,1]
+  ];
+  const INDEX = [
+    [0,0,0,0],[1,1,1,1],[2,2,2,2],
+    [0,1,0,1],[1,2,1,2],[2,0,2,0],
+    [0,2,0,2],[1,0,1,0],[2,1,2,1]
+  ];
+
+  const MASK5 = 0x55555555;
+  const MASK3 = 0x33333333;
+
+  // ===== PRIMITIVES =====
+
+  // S: split MSB-first into 6/5/5/5/5/6-bit fields, substitute, recombine.
+  function sFunc(x) {
+    let result = OpCodes.Shl32(S6[OpCodes.And32(OpCodes.Shr32(x, 26), 0x3F)], 26);
+    result = OpCodes.Or32(result, OpCodes.Shl32(S5[OpCodes.And32(OpCodes.Shr32(x, 21), 0x1F)], 21));
+    result = OpCodes.Or32(result, OpCodes.Shl32(S5[OpCodes.And32(OpCodes.Shr32(x, 16), 0x1F)], 16));
+    result = OpCodes.Or32(result, OpCodes.Shl32(S5[OpCodes.And32(OpCodes.Shr32(x, 11), 0x1F)], 11));
+    result = OpCodes.Or32(result, OpCodes.Shl32(S5[OpCodes.And32(OpCodes.Shr32(x, 6), 0x1F)], 6));
+    result = OpCodes.Or32(result, S6[OpCodes.And32(x, 0x3F)]);
+    return result;
+  }
+
+  // M: 32x32 GF(2) matrix multiply.
+  function mFunc(x) {
+    let acc = 0;
+    for (let b = 0; b < 32; ++b) {
+      if (OpCodes.And32(OpCodes.Shr32(x, b), 1) !== 0)
+        acc = OpCodes.Xor32(acc, MATRIX[31 - b]);
+    }
+    return acc;
+  }
+
+  function msFunc(x) { return mFunc(sFunc(x)); }
+
+  // B: transpose the four state words into 32 nibbles, substitute, transpose
+  // back. Feeding S4I instead of S4 gives B^-1.
+  function bFunc(state, table) {
+    let o0 = 0, o1 = 0, o2 = 0, o3 = 0;
+    for (let bit = 0; bit < 32; ++bit) {
+      const a = OpCodes.And32(OpCodes.Shr32(state[0], bit), 1);
+      const b = OpCodes.And32(OpCodes.Shr32(state[1], bit), 1);
+      const c = OpCodes.And32(OpCodes.Shr32(state[2], bit), 1);
+      const d = OpCodes.And32(OpCodes.Shr32(state[3], bit), 1);
+      const nibble = OpCodes.Or32(OpCodes.Or32(OpCodes.Or32(OpCodes.Shl32(a, 3), OpCodes.Shl32(b, 2)), OpCodes.Shl32(c, 1)), d);
+      const value = table[nibble];
+      if (OpCodes.And32(OpCodes.Shr32(value, 3), 1) !== 0) o0 = OpCodes.Or32(o0, OpCodes.Shl32(1, bit));
+      if (OpCodes.And32(OpCodes.Shr32(value, 2), 1) !== 0) o1 = OpCodes.Or32(o1, OpCodes.Shl32(1, bit));
+      if (OpCodes.And32(OpCodes.Shr32(value, 1), 1) !== 0) o2 = OpCodes.Or32(o2, OpCodes.Shl32(1, bit));
+      if (OpCodes.And32(value, 1) !== 0)                   o3 = OpCodes.Or32(o3, OpCodes.Shl32(1, bit));
+    }
+    return [o0, o1, o2, o3];
+  }
+
+  // I: XOR four extended-key words into the state.
+  function iFunc(state, rk, offset) {
+    return [
+      OpCodes.Xor32(state[0], rk[offset]),
+      OpCodes.Xor32(state[1], rk[offset + 1]),
+      OpCodes.Xor32(state[2], rk[offset + 2]),
+      OpCodes.Xor32(state[3], rk[offset + 3])
+    ];
+  }
+
+  // F = L(M(S(a)), M(S(b)), mask)
+  function fFunc(a, b, mask) {
+    const x = msFunc(a);
+    const y = msFunc(b);
+    return [
+      OpCodes.Xor32(OpCodes.And32(mask, x), y),
+      OpCodes.Xor32(OpCodes.And32(OpCodes.Not32(mask), y), x)
+    ];
+  }
+
+  // One RxR pair: a Feistel round, the cross connection (a,b,c,d)->(c,d,a,b),
+  // and a second Feistel round. Both R and the pair as a whole are involutions,
+  // which is why decryption reuses this function unchanged.
+  function rFuncPair(state, mask) {
+    const [a, b, c, d] = state;
+    const [s1, t1] = fFunc(c, d, mask);
+    const a1 = OpCodes.Xor32(a, s1);
+    const b1 = OpCodes.Xor32(b, t1);
+    const [s2, t2] = fFunc(a1, b1, mask);
+    return [OpCodes.Xor32(c, s2), OpCodes.Xor32(d, t2), a1, b1];
+  }
 
   // ===== ALGORITHM IMPLEMENTATION =====
 
-class SC2000 extends BlockCipherAlgorithm {
-  constructor() {
-    super();
+  class SC2000 extends BlockCipherAlgorithm {
+    constructor() {
+      super();
 
-    this.name = "SC2000";
-    this.description = "Educational implementation of SC2000 block cipher from Fujitsu Labs with hybrid Feistel/SPN structure, submitted to NESSIE and recommended by CRYPTREC.";
-    this.inventor = "Fujitsu Labs";
-    this.year = 2000;
-    this.category = CategoryType.BLOCK;
-    this.subCategory = "Block Cipher";
-    this.securityStatus = SecurityStatus.EDUCATIONAL;
-    this.complexity = ComplexityType.INTERMEDIATE;
-    this.country = CountryCode.JP;
+      this.name = "SC2000";
+      this.description = "Fujitsu Laboratories block cipher combining an SPN half-round (subkey XOR plus a bit-sliced 4-bit S-box layer) with pairs of Feistel rounds built from 6-bit and 5-bit S-boxes and a 32x32 GF(2) diffusion matrix. 128-bit block; 6.5 rounds for a 128-bit key and 7.5 for 192/256-bit keys. Submitted to NESSIE and listed by CRYPTREC.";
+      this.inventor = "Takeshi Shimoyama, Hirotaka Yanami, Kazuhiro Yokoyama, Masahiko Takenaka, Kouichi Itoh, Jun Yajima, Naoya Torii, Hidema Tanaka";
+      this.year = 2000;
+      this.category = CategoryType.BLOCK;
+      this.subCategory = "Block Cipher";
+      this.securityStatus = SecurityStatus.EDUCATIONAL;
+      this.complexity = ComplexityType.EXPERT;
+      this.country = CountryCode.JP;
 
-    this.SupportedKeySizes = [new KeySize(16, 32, 8)];
-    this.SupportedBlockSizes = [new KeySize(16, 16, 1)];
+      this.SupportedKeySizes = [new KeySize(16, 32, 8)];
+      this.SupportedBlockSizes = [new KeySize(16, 16, 1)];
 
-    this.documentation = [
-      new LinkItem("SC2000 Specification", "https://www.fujitsu.com/global/about/research/external-activities/crypto/sc2000.html")
-    ];
+      this.documentation = [
+        new LinkItem("SC2000 specification (CRYPTREC)", "https://www.cryptrec.go.jp/cryptrec_03_spec_cypherlist_files/PDF/09_01jspec.pdf"),
+        new LinkItem("The Block Cipher SC2000 (FSE 2001)", "https://link.springer.com/content/pdf/10.1007/3-540-45473-X_26.pdf"),
+        new LinkItem("SC2000 (Fujitsu)", "https://www.fujitsu.com/global/about/research/external-activities/crypto/sc2000.html")
+      ];
 
-    this.references = [
-      new LinkItem("embeddedsw.net libObfuscate SC2000 Implementation", "https://embeddedsw.net/Cipher_Reference_Home.html")
-    ];
+      this.references = [
+        new LinkItem("Fujitsu NESSIE submission package (includes the official test vectors)", "https://www.cosic.esat.kuleuven.be/nessie/workshop/submissions/sc2000.zip"),
+        new LinkItem("Security Analysis of the Block Cipher SC2000 (CRYPTREC, 2012)", "https://www.cryptrec.go.jp/exreport/cryptrec-ex-2202-2012p3.pdf")
+      ];
 
-    this.tests = [
-      {
-        text: "SC2000 Test Vector 1",
-        uri: "Educational test vector for SC2000 cipher",
-        input: OpCodes.Hex8ToBytes('00112233445566778899AABBCCDDEEFF'),
-        key: OpCodes.Hex8ToBytes('0F0E0D0C0B0A09080706050403020100'),
-        expected: OpCodes.Hex8ToBytes('00020036000500070029000B0027001E')
-      }
-    ];
+      this.knownVulnerabilities = [
+        new Vulnerability("Reduced-round differential and boomerang attacks", "Attacks are published against reduced-round variants; the full cipher is unbroken but CRYPTREC has moved it off its recommended list.", "Use AES or another currently recommended cipher.")
+      ];
+
+      // Official test vectors: the all-zero case is published in the CRYPTREC
+      // specification's worked example (appendix A) and again in Fujitsu's NESSIE
+      // submission; the rest are from the NESSIE submission's testvectors128.txt
+      // and testvectors{192,256}.txt.
+      this.tests = [
+        {
+          text: "CRYPTREC specification appendix A — 128-bit zero key and plaintext",
+          uri: "https://www.cryptrec.go.jp/cryptrec_03_spec_cypherlist_files/PDF/09_01jspec.pdf",
+          input: OpCodes.Hex8ToBytes('00000000000000000000000000000000'),
+          key: OpCodes.Hex8ToBytes('00000000000000000000000000000000'),
+          expected: OpCodes.Hex8ToBytes('fae4baa3bb72c4c060b9a4a5c4b2ab32')
+        },
+        {
+          text: "NESSIE submission testvectors128.txt — single key bit set",
+          uri: "https://www.cosic.esat.kuleuven.be/nessie/workshop/submissions/sc2000.zip",
+          input: OpCodes.Hex8ToBytes('00000000000000000000000000000000'),
+          key: OpCodes.Hex8ToBytes('80000000000000000000000000000000'),
+          expected: OpCodes.Hex8ToBytes('3fcb3bc9dbe00a8bf28d69d7f67102a7')
+        },
+        {
+          text: "NESSIE submission testvectors128.txt — single plaintext bit set",
+          uri: "https://www.cosic.esat.kuleuven.be/nessie/workshop/submissions/sc2000.zip",
+          input: OpCodes.Hex8ToBytes('80000000000000000000000000000000'),
+          key: OpCodes.Hex8ToBytes('00000000000000000000000000000000'),
+          expected: OpCodes.Hex8ToBytes('b75cd863b9cb21c7cebd9e1014bf774f')
+        },
+        {
+          text: "NESSIE submission testvectors128.txt — repeating 0x01 key and plaintext",
+          uri: "https://www.cosic.esat.kuleuven.be/nessie/workshop/submissions/sc2000.zip",
+          input: OpCodes.Hex8ToBytes('01010101010101010101010101010101'),
+          key: OpCodes.Hex8ToBytes('01010101010101010101010101010101'),
+          expected: OpCodes.Hex8ToBytes('ee5c548ea5ef353b896a780e324be38d')
+        },
+        {
+          text: "NESSIE submission testvectors128.txt — repeating 0x09 key and plaintext",
+          uri: "https://www.cosic.esat.kuleuven.be/nessie/workshop/submissions/sc2000.zip",
+          input: OpCodes.Hex8ToBytes('09090909090909090909090909090909'),
+          key: OpCodes.Hex8ToBytes('09090909090909090909090909090909'),
+          expected: OpCodes.Hex8ToBytes('8839d41b099a817ef8f9ffe6b88455ce')
+        },
+        {
+          text: "NESSIE submission testvectors192.txt — 192-bit zero key and plaintext",
+          uri: "https://www.cosic.esat.kuleuven.be/nessie/workshop/submissions/sc2000.zip",
+          input: OpCodes.Hex8ToBytes('00000000000000000000000000000000'),
+          key: OpCodes.Hex8ToBytes('000000000000000000000000000000000000000000000000'),
+          expected: OpCodes.Hex8ToBytes('6c2bab231cb641ed3ac8d4b0ea69ee3b')
+        },
+        {
+          text: "NESSIE submission testvectors256.txt — 256-bit zero key and plaintext",
+          uri: "https://www.cosic.esat.kuleuven.be/nessie/workshop/submissions/sc2000.zip",
+          input: OpCodes.Hex8ToBytes('00000000000000000000000000000000'),
+          key: OpCodes.Hex8ToBytes('0000000000000000000000000000000000000000000000000000000000000000'),
+          expected: OpCodes.Hex8ToBytes('6c2bab231cb641ed3ac8d4b0ea69ee3b')
+        }
+      ];
+    }
+
+    CreateInstance(isInverse = false) {
+      return new SC2000Instance(this, isInverse);
+    }
   }
 
-  CreateInstance(isInverse = false) {
-    return new SC2000Instance(this, isInverse);
-  }
-}
-
-class SC2000Instance extends IBlockCipherInstance {
-  constructor(algorithm, isInverse = false) {
-    super(algorithm);
-    this.isInverse = isInverse;
-    this.inputBuffer = [];
-    this._key = null;
-    this._roundKeys = null;
-    this._rounds = 0;
-
-    this._sBox4 = [
-      0xC, 0x5, 0x6, 0xB, 0x9, 0x0, 0xA, 0xD,
-      0x3, 0xE, 0xF, 0x8, 0x4, 0x7, 0x1, 0x2
-    ];
-
-    this._sBox5 = [
-      0x1E, 0x11, 0x0A, 0x07, 0x16, 0x1D, 0x04, 0x09,
-      0x12, 0x0F, 0x18, 0x03, 0x1A, 0x05, 0x0C, 0x13,
-      0x00, 0x0B, 0x1F, 0x06, 0x17, 0x02, 0x14, 0x1B,
-      0x0E, 0x19, 0x08, 0x01, 0x10, 0x15, 0x1C, 0x0D
-    ];
-
-    this._sBox6 = [
-      0x2F, 0x25, 0x1A, 0x0F, 0x34, 0x39, 0x08, 0x13,
-      0x26, 0x1B, 0x30, 0x05, 0x3A, 0x0D, 0x18, 0x23,
-      0x00, 0x15, 0x2A, 0x3F, 0x16, 0x0B, 0x20, 0x35,
-      0x2C, 0x31, 0x06, 0x1B, 0x24, 0x19, 0x0E, 0x03,
-      0x38, 0x2D, 0x02, 0x17, 0x22, 0x37, 0x0C, 0x01,
-      0x1E, 0x33, 0x28, 0x3D, 0x12, 0x07, 0x1C, 0x21,
-      0x36, 0x0B, 0x10, 0x25, 0x3A, 0x2F, 0x04, 0x09,
-      0x14, 0x29, 0x3E, 0x33, 0x08, 0x1D, 0x32, 0x27
-    ];
-  }
-
-  set key(keyBytes) {
-    if (!keyBytes) {
+  class SC2000Instance extends IBlockCipherInstance {
+    constructor(algorithm, isInverse = false) {
+      super(algorithm);
+      this.isInverse = isInverse;
+      this.inputBuffer = [];
       this._key = null;
       this._roundKeys = null;
-      return;
+      this._rounds = 0;
+      this.BlockSize = 16;
+      this.KeySize = 0;
     }
 
-    const isValidSize = this.algorithm.SupportedKeySizes.some(ks =>
-      keyBytes.length >= ks.minSize && keyBytes.length <= ks.maxSize
-    );
-
-    if (!isValidSize) {
-      throw new Error(`Invalid key size: ${keyBytes.length} bytes`);
-    }
-
-    this._key = [...keyBytes];
-    this._rounds = this._getRounds(keyBytes.length);
-    this._roundKeys = this._expandKey(keyBytes);
-  }
-
-  get key() { return this._key ? [...this._key] : null; }
-
-  Feed(data) {
-    if (!data || data.length === 0) return;
-    if (!this._key) throw new Error("Key not set");
-    for (let _i = 0; _i < data.length; _i++) this.inputBuffer.push(data[_i]);
-  }
-
-  Result() {
-    if (!this._key) throw new Error("Key not set");
-    if (this.inputBuffer.length === 0) throw new Error("No data fed");
-
-    const output = [];
-    const blockSize = 16;
-
-    for (let i = 0; i < this.inputBuffer.length; i += blockSize) {
-      const block = this.inputBuffer.slice(i, i + blockSize);
-      if (block.length !== blockSize) {
-        throw new Error(`Incomplete block: ${block.length} bytes`);
+    set key(keyBytes) {
+      if (!keyBytes) {
+        this._key = null;
+        this._roundKeys = null;
+        this.KeySize = 0;
+        return;
       }
 
-      const processedBlock = this.isInverse ?
-        this._decryptBlock(block) :
-        this._encryptBlock(block);
+      const isValidSize = this.algorithm.SupportedKeySizes.some(ks =>
+        keyBytes.length >= ks.minSize && keyBytes.length <= ks.maxSize
+        && (ks.stepSize === 0 || (keyBytes.length - ks.minSize) % ks.stepSize === 0)
+      );
 
-      for (let _i = 0; _i < processedBlock.length; _i++) output.push(processedBlock[_i]);
-    }
-
-    this.inputBuffer = [];
-    return output;
-  }
-
-  _getRounds(keyLength) {
-    switch (keyLength) {
-      case 16: return 7;  // 6.5 rounds (7 for simplicity)
-      case 24: return 8;  // 7.5 rounds
-      case 32: return 8;  // 7.5 rounds
-      default: return 7;
-    }
-  }
-
-  _expandKey(key) {
-    const totalKeys = this._rounds + 2;
-    const roundKeys = new Array(totalKeys);
-
-    for (let i = 0; i < totalKeys; i++) {
-      roundKeys[i] = new Uint8Array(8);
-    }
-
-    for (let i = 0; i < totalKeys; i++) {
-      for (let j = 0; j < 8; j++) {
-        roundKeys[i][j] = key[(i * 8 + j) % key.length];
-        roundKeys[i][j] = OpCodes.Xor32(roundKeys[i][j], OpCodes.RotL8(key[(i + j) % key.length], (i + j)&7));
-        roundKeys[i][j] = OpCodes.Xor32(roundKeys[i][j], OpCodes.ToByte(i * 16 + j * 3 + 0x5A));
+      if (!isValidSize) {
+        throw new Error(`Invalid key size: ${keyBytes.length} bytes`);
       }
+
+      this._key = [...keyBytes];
+      this.KeySize = keyBytes.length;
+      // 6.5 rounds for a 128-bit key, 7.5 for 192 and 256.
+      this._rounds = keyBytes.length === 16 ? 6 : 7;
+      this._roundKeys = this._expandKey(this._key);
     }
 
-    return roundKeys;
-  }
+    get key() { return this._key ? [...this._key] : null; }
 
-  _encryptBlock(data) {
-    let left = new Uint8Array(data.slice(0, 8));
-    let right = new Uint8Array(data.slice(8, 16));
-
-    for (let round = 0; round < this._rounds; round++) {
-      const tempRight = new Uint8Array(right);
-      right = OpCodes.XorArrays(left, this._fFunction(right, this._roundKeys[round]));
-      left = tempRight;
+    Feed(data) {
+      if (!data || data.length === 0) return;
+      if (!this._key) throw new Error("Key not set");
+      for (let _i = 0; _i < data.length; _i++) this.inputBuffer.push(data[_i]);
     }
 
-    this._spnLayer(left, this._roundKeys[this._rounds]);
-    this._spnLayer(right, this._roundKeys[this._rounds + 1]);
+    Result() {
+      if (!this._key) throw new Error("Key not set");
+      if (this.inputBuffer.length === 0) throw new Error("No data fed");
+      if (this.inputBuffer.length % this.BlockSize !== 0)
+        throw new Error(`Input length must be a multiple of ${this.BlockSize} bytes`);
 
-    return new Uint8Array([...left, ...right]);
-  }
+      const output = [];
+      for (let i = 0; i < this.inputBuffer.length; i += this.BlockSize) {
+        const block = this.inputBuffer.slice(i, i + this.BlockSize);
+        const processed = this.isInverse ? this._decryptBlock(block) : this._encryptBlock(block);
+        for (let _i = 0; _i < processed.length; _i++) output.push(processed[_i]);
+      }
 
-  _decryptBlock(data) {
-    let left = new Uint8Array(data.slice(0, 8));
-    let right = new Uint8Array(data.slice(8, 16));
-
-    this._invSpnLayer(left, this._roundKeys[this._rounds + 1]);
-    this._invSpnLayer(right, this._roundKeys[this._rounds]);
-
-    for (let round = this._rounds - 1; round >= 0; round--) {
-      const tempLeft = new Uint8Array(left);
-      left = OpCodes.XorArrays(right, this._fFunction(left, this._roundKeys[round]));
-      right = tempLeft;
+      this.inputBuffer = [];
+      return output;
     }
 
-    return new Uint8Array([...left, ...right]);
-  }
+    // The mask of Feistel pair index r: R5 for even, R3 for odd.
+    _maskOf(r) { return (r % 2) === 0 ? MASK5 : MASK3; }
 
-  _fFunction(input, roundKey) {
-    const result = new Uint8Array(8);
+    _expandKey(keyBytes) {
+      // Step 1: read the master key big-endian and extend it to eight words.
+      // A 128-bit key repeats its four words; a 192-bit key repeats its first
+      // two; a 256-bit key is used as it stands.
+      const words = [];
+      for (let i = 0; i < keyBytes.length / 4; ++i)
+        words.push(OpCodes.Pack32BE(keyBytes[i * 4], keyBytes[i * 4 + 1], keyBytes[i * 4 + 2], keyBytes[i * 4 + 3]));
 
-    for (let i = 0; i < 8; i++) {
-      result[i] = OpCodes.Xor32(input[i], roundKey[i]);
-    }
+      const uk = new Array(8);
+      for (let i = 0; i < words.length; ++i) uk[i] = words[i];
+      if (words.length === 4) {
+        uk[4] = uk[0]; uk[5] = uk[1]; uk[6] = uk[2]; uk[7] = uk[3];
+      } else if (words.length === 6) {
+        uk[6] = uk[0]; uk[7] = uk[1];
+      }
 
-    for (let i = 0; i < 8; i++) {
-      result[i] = this._sBox4[result[i]&0x0F];
-    }
-
-    result[0] = OpCodes.Xor32(result[0], result[1]);
-    result[2] = OpCodes.Xor32(result[2], result[3]);
-    result[4] = OpCodes.Xor32(result[4], result[5]);
-    result[6] = OpCodes.Xor32(result[6], result[7]);
-
-    const left = OpCodes.Pack32BE(result[0], result[1], result[2], result[3]);
-    const right = OpCodes.Pack32BE(result[4], result[5], result[6], result[7]);
-
-    const mixedLeft = OpCodes.Xor32(OpCodes.RotL32(left, 7), right);
-    const mixedRight = OpCodes.Xor32(OpCodes.RotL32(right, 13), left);
-
-    const finalResult = new Uint8Array(8);
-    finalResult[0] = (OpCodes.Shr32(mixedLeft, 24))&0xFF;
-    finalResult[1] = (OpCodes.Shr32(mixedLeft, 16))&0xFF;
-    finalResult[2] = (OpCodes.Shr32(mixedLeft, 8))&0xFF;
-    finalResult[3] = mixedLeft&0xFF;
-    finalResult[4] = (OpCodes.Shr32(mixedRight, 24))&0xFF;
-    finalResult[5] = (OpCodes.Shr32(mixedRight, 16))&0xFF;
-    finalResult[6] = (OpCodes.Shr32(mixedRight, 8))&0xFF;
-    finalResult[7] = mixedRight&0xFF;
-
-    return finalResult;
-  }
-
-  _spnLayer(state, roundKey) {
-    for (let i = 0; i < 8; i++) {
-      state[i] = OpCodes.Xor32(state[i], roundKey[i]);
-    }
-
-    for (let i = 0; i < 8; i += 2) {
-      const combined = (OpCodes.Shl32(state[i], 8))|state[i + 1];
-      const sboxValue = OpCodes.Xor32(this._sBox5[combined&0x1F], this._sBox6[(OpCodes.Shr32(combined, 5))&0x3F]);
-      state[i] = OpCodes.ToByte(OpCodes.Shr32(sboxValue, 8));
-      state[i + 1] = OpCodes.ToByte(sboxValue);
-    }
-
-    const temp = state[0];
-    state[0] = state[2];
-    state[2] = state[4];
-    state[4] = state[6];
-    state[6] = temp;
-
-    const temp2 = state[1];
-    state[1] = state[3];
-    state[3] = state[5];
-    state[5] = state[7];
-    state[7] = temp2;
-  }
-
-  _invSpnLayer(state, roundKey) {
-    const temp = state[6];
-    state[6] = state[4];
-    state[4] = state[2];
-    state[2] = state[0];
-    state[0] = temp;
-
-    const temp2 = state[7];
-    state[7] = state[5];
-    state[5] = state[3];
-    state[3] = state[1];
-    state[1] = temp2;
-
-    for (let i = 0; i < 8; i += 2) {
-      const combined = (OpCodes.Shl32(state[i], 8))|state[i + 1];
-      for (let j = 0; j < 65536; j++) {
-        const testVal = OpCodes.Xor32(this._sBox5[j&0x1F], this._sBox6[(OpCodes.Shr32(j, 5))&0x3F]);
-        if (testVal === combined) {
-          state[i] = OpCodes.ToByte(OpCodes.Shr32(j, 8));
-          state[i + 1] = OpCodes.ToByte(j);
-          break;
+      // Step 2: twelve intermediate key words, three per branch. Branch j takes
+      // uk[2j] and uk[2j+1]; the "constants" are simply 4i+j pushed through M(S(.)).
+      const intermediate = new Array(12);
+      for (let branch = 0; branch < 4; ++branch) {
+        const u0 = msFunc(uk[branch * 2]);
+        const u1 = msFunc(uk[branch * 2 + 1]);
+        for (let i = 0; i < 3; ++i) {
+          const constant = msFunc(4 * i + branch);
+          const sum = OpCodes.Add32(u0, constant);
+          const scaled = OpCodes.ToUint32((i + 1) * u1);
+          intermediate[branch * 3 + i] = msFunc(OpCodes.Xor32(sum, scaled));
         }
       }
+
+      // Step 3: the extended keys.
+      //   ek[n] = ((X[x] ROTL 1) + Y[y]) XOR (((Z[z] ROTL 1) - W[w]) ROTL 1)
+      const count = this._rounds === 6 ? 56 : 64;
+      const rk = new Array(count);
+      for (let n = 0; n < count; ++n) {
+        const order = ORDER[(n + Math.floor(n / 36)) % 12];
+        const index = INDEX[n % 9];
+        const x = intermediate[order[0] * 3 + index[0]];
+        const y = intermediate[order[1] * 3 + index[1]];
+        const z = intermediate[order[2] * 3 + index[2]];
+        const w = intermediate[order[3] * 3 + index[3]];
+        const first = OpCodes.Add32(OpCodes.RotL32(x, 1), y);
+        const second = OpCodes.RotL32(OpCodes.Sub32(OpCodes.RotL32(z, 1), w), 1);
+        rk[n] = OpCodes.Xor32(first, second);
+      }
+      return rk;
     }
 
-    for (let i = 0; i < 8; i++) {
-      state[i] = OpCodes.Xor32(state[i], roundKey[i]);
+    _loadBlock(block) {
+      return [
+        OpCodes.Pack32BE(block[0], block[1], block[2], block[3]),
+        OpCodes.Pack32BE(block[4], block[5], block[6], block[7]),
+        OpCodes.Pack32BE(block[8], block[9], block[10], block[11]),
+        OpCodes.Pack32BE(block[12], block[13], block[14], block[15])
+      ];
+    }
+
+    _storeBlock(state) {
+      const out = [];
+      for (let i = 0; i < 4; ++i) {
+        const bytes = OpCodes.Unpack32BE(state[i]);
+        for (let j = 0; j < 4; ++j) out.push(bytes[j]);
+      }
+      return out;
+    }
+
+    _encryptBlock(block) {
+      const rk = this._roundKeys;
+      let state = this._loadBlock(block);
+
+      for (let r = 0; r < this._rounds; ++r) {
+        state = iFunc(state, rk, 8 * r);
+        state = bFunc(state, S4);
+        state = iFunc(state, rk, 8 * r + 4);
+        state = rFuncPair(state, this._maskOf(r));
+      }
+
+      // Trailing half-round.
+      state = iFunc(state, rk, 8 * this._rounds);
+      state = bFunc(state, S4);
+      state = iFunc(state, rk, 8 * this._rounds + 4);
+
+      return this._storeBlock(state);
+    }
+
+    _decryptBlock(block) {
+      const rk = this._roundKeys;
+      let state = this._loadBlock(block);
+
+      state = iFunc(state, rk, 8 * this._rounds + 4);
+      state = bFunc(state, S4I);
+      state = iFunc(state, rk, 8 * this._rounds);
+
+      for (let r = this._rounds - 1; r >= 0; --r) {
+        state = rFuncPair(state, this._maskOf(r));
+        state = iFunc(state, rk, 8 * r + 4);
+        state = bFunc(state, S4I);
+        state = iFunc(state, rk, 8 * r);
+      }
+
+      return this._storeBlock(state);
     }
   }
-}
 
   // ===== REGISTRATION =====
 

--- a/Cipher/algorithms/block/sc2000.js
+++ b/Cipher/algorithms/block/sc2000.js
@@ -24,7 +24,7 @@
  *   I(a,b,c,d, k0..k3) = (a^k0, b^k1, c^k2, d^k3)
  *   R(a,b,c,d, mask)   = (a^s, b^t, c, d) where (s,t) = F(c,d,mask)
  *   F(a,b,mask)        = L(M(S(a)), M(S(b)), mask)
- *   L(a,b,mask)        = ((a AND mask) ^ b, (b AND NOT mask) ^ a)
+ *   L(a,b,mask)        = (XOR(a AND mask, b), XOR(b AND NOT mask, a))
  *   S splits a word MSB-first into 6/5/5/5/5/6-bit fields and runs the outer
  *     fields through S6 and the inner four through S5.
  *   M is a 32x32 GF(2) matrix multiply: bit i of the input (bit 0 being the

--- a/Cipher/algorithms/block/speed.js
+++ b/Cipher/algorithms/block/speed.js
@@ -114,8 +114,6 @@
     [0x9BF4, 0xF659, 0xD76C]  // l = 256
   ];
 
-  // Recommended round counts (paper, Table 1) keyed by block width in bits.
-  const DEFAULT_ROUNDS = { 64: 64, 128: 48, 256: 48 };
 
   // ===== WORD HELPERS =====
 
@@ -170,7 +168,13 @@
     return OpCodes.Xor32(r, t[2]);
   }
 
-  const PASS_FUNCTIONS = [f1, f2, f3, f4];
+  // Pass p of four uses Boolean function F(p+1).
+  function combineForPass(pass, t) {
+    if (pass === 0) return f1(t);
+    if (pass === 1) return f2(t);
+    if (pass === 2) return f3(t);
+    return f4(t);
+  }
 
   // ===== ALGORITHM IMPLEMENTATION =====
 
@@ -248,8 +252,8 @@
       this.isInverse = isInverse;
       this.inputBuffer = [];
       this._key = null;
-      this._blockSize = 16;   // bytes; w = 128 bits
-      this._rounds = null;    // null means "use the recommended count for w"
+      this._widthBytes = 16;   // bytes; w = 128 bits
+      this._rounds = 0;       // 0 means "use the recommended count for w"
       this._roundKeys = null;
       this.BlockSize = 16;
       this.KeySize = 0;
@@ -279,25 +283,31 @@
 
     get key() { return this._key ? [...this._key] : null; }
 
-    set blockSize(bytes) {
-      if (bytes !== 8 && bytes !== 16 && bytes !== 32)
-        throw new Error(`Invalid block size: ${bytes} bytes. SPEED supports 8, 16 or 32`);
-      this._blockSize = bytes;
-      this.BlockSize = bytes;
+    set blockSize(width) {
+      if (width !== 8 && width !== 16 && width !== 32)
+        throw new Error(`Invalid block size: ${width} bytes. SPEED supports 8, 16 or 32`);
+      this._widthBytes = width;
+      this.BlockSize = width;
       this._roundKeys = null;
     }
 
-    get blockSize() { return this._blockSize; }
+    get blockSize() { return this._widthBytes; }
 
     set rounds(count) {
-      if (count === null || count === undefined) { this._rounds = null; this._roundKeys = null; return; }
+      if (!count) { this._rounds = 0; this._roundKeys = null; return; }
       if (count < 32 || count % 4 !== 0)
         throw new Error(`Invalid round count: ${count}. SPEED requires a multiple of 4, at least 32`);
       this._rounds = count;
       this._roundKeys = null;
     }
 
-    get rounds() { return this._rounds === null ? DEFAULT_ROUNDS[this._blockSize * 8] : this._rounds; }
+    get rounds() {
+      // Zero means "unset": fall back to the paper's Table 1 recommendation of
+      // 64 rounds for a 64-bit block and 48 for 128 and 256.
+      if (this._rounds !== 0) return this._rounds;
+      if (this._widthBytes === 8) return 64;
+      return 48;
+    }
 
     Feed(data) {
       if (!data || data.length === 0) return;
@@ -308,14 +318,14 @@
     Result() {
       if (!this._key) throw new Error("Key not set");
       if (this.inputBuffer.length === 0) throw new Error("No data fed");
-      if (this.inputBuffer.length % this._blockSize !== 0)
-        throw new Error(`Input length must be a multiple of ${this._blockSize} bytes`);
+      if (this.inputBuffer.length % this._widthBytes !== 0)
+        throw new Error(`Input length must be a multiple of ${this._widthBytes} bytes`);
 
       if (!this._roundKeys) this._roundKeys = this._expandKey();
 
       const output = [];
-      for (let i = 0; i < this.inputBuffer.length; i += this._blockSize) {
-        const block = this.inputBuffer.slice(i, i + this._blockSize);
+      for (let i = 0; i < this.inputBuffer.length; i += this._widthBytes) {
+        const block = this.inputBuffer.slice(i, i + this._widthBytes);
         const processed = this.isInverse ? this._decryptBlock(block) : this._encryptBlock(block);
         for (let _i = 0; _i < processed.length; _i++) output.push(processed[_i]);
       }
@@ -326,7 +336,7 @@
 
     // Geometry of the current parameter set.
     _shape() {
-      const blockBits = this._blockSize * 8;
+      const blockBits = this._widthBytes * 8;
       const wordBits = blockBits / 8;            // 8, 16 or 32
       const wordBytes = wordBits / 8;            // 1, 2 or 4
       const fullMask = wordBits === 32 ? 0xFFFFFFFF : OpCodes.Shl32(1, wordBits) - 1;
@@ -334,7 +344,7 @@
       const halfMask = OpCodes.Shl32(1, halfBits) - 1;
       // vv must span the whole 0..wordBits-1 rotation range, so the half-word is
       // shifted down to leave exactly log2(wordBits) bits: 1, 4 and 11.
-      const vvShift = halfBits - Math.log2(wordBits);
+      const vvShift = wordBits === 8 ? 1 : (wordBits === 16 ? 4 : 11);
       return { blockBits, wordBits, wordBytes, fullMask, halfBits, halfMask, vvShift, fixedRotate: halfBits - 1 };
     }
 
@@ -400,7 +410,7 @@
 
     _storeBlock(t) {
       const { wordBytes } = this._shape();
-      const out = new Array(this._blockSize);
+      const out = new Array(this._widthBytes);
       for (let i = 0; i < 8; ++i) {
         const at = (7 - i) * wordBytes;
         for (let b = 0; b < wordBytes; ++b)
@@ -417,9 +427,8 @@
       let t = this._loadBlock(block);
 
       for (let n = 0; n < rounds; ++n) {
-        const combine = PASS_FUNCTIONS[Math.floor(n / perPass)];
         const tail = rotR(t[7], fixedRotate, wordBits, fullMask);
-        let tmp = OpCodes.And32(combine(t), fullMask);
+        let tmp = OpCodes.And32(combineForPass(Math.floor(n / perPass), t), fullMask);
         const vv = OpCodes.Shr32(OpCodes.And32(OpCodes.Add32(OpCodes.Shr32(tmp, halfBits), tmp), halfMask), vvShift);
         tmp = rotR(tmp, vv, wordBits, fullMask);
         const head = OpCodes.And32(OpCodes.Add32(OpCodes.Add32(tail, tmp), rk[n]), fullMask);
@@ -440,8 +449,7 @@
         // Everything except the tail word is simply the queue shifted back one
         // place; the tail is what the round consumed into the new head.
         const previous = [t[1], t[2], t[3], t[4], t[5], t[6], t[7], 0];
-        const combine = PASS_FUNCTIONS[Math.floor(n / perPass)];
-        let tmp = OpCodes.And32(combine(previous), fullMask);
+        let tmp = OpCodes.And32(combineForPass(Math.floor(n / perPass), previous), fullMask);
         const vv = OpCodes.Shr32(OpCodes.And32(OpCodes.Add32(OpCodes.Shr32(tmp, halfBits), tmp), halfMask), vvShift);
         tmp = rotR(tmp, vv, wordBits, fullMask);
         const tail = OpCodes.And32(OpCodes.Sub32(OpCodes.Sub32(t[0], tmp), rk[n]), fullMask);

--- a/Cipher/algorithms/block/speed.js
+++ b/Cipher/algorithms/block/speed.js
@@ -1,3 +1,63 @@
+/*
+ * SPEED Implementation
+ * Compatible with AlgorithmFramework
+ * (c)2006-2025 Hawkynt
+ *
+ * SPEED, by Yuliang Zheng, presented at Financial Cryptography '97 (Anguilla,
+ * February 1997; LNCS 1318, pages 71-89). An unbalanced Feistel network over a
+ * queue of eight words: each round derives one new word from a nonlinear
+ * Boolean combination of the other seven, rotates it by an amount computed from
+ * itself, adds the discarded tail word and a round key, and shifts the queue.
+ *
+ * Parameters (paper, section 2):
+ *   - block width w of 64, 128 or 256 bits, always eight words of w/8 bits;
+ *   - key length l, any multiple of 16 bits from 48 to 256;
+ *   - round count r, any multiple of 4 that is at least 32. The paper's Table 1
+ *     recommends r = 64 for w = 64 and r = 48 for w = 128 and w = 256; those are
+ *     the defaults here, and both are overridable.
+ * The rounds are split into four equal passes P1..P4, each with its own round
+ * keys and its own Boolean function F1..F4.
+ *
+ * Round function (paper, section 2.1), with FULL = 2^(w/8)-1, HALF = 2^(w/16)-1:
+ *     t7  = ROTR(t7, w/16 - 1)
+ *     tmp = Fi(t6, t5, t4, t3, t2, t1, t0)
+ *     vv  = SHR(SHR(tmp, w/16) + tmp AND HALF, VV_SHIFT)
+ *     tmp = ROTR(tmp, vv)
+ *     tmp = (t7 + tmp + Ki[j]) AND FULL
+ *     (t7,t6,t5,t4,t3,t2,t1,t0) = (t6,t5,t4,t3,t2,t1,t0,tmp)
+ * VV_SHIFT is 1, 4 and 11 for w = 64, 128 and 256, so vv covers the full 0..w/8-1
+ * rotation range. All rotations are to the right.
+ *
+ * The four Boolean functions (paper, section 4.2), juxtaposition meaning AND and
+ * every operation applied bit-slice across the word:
+ *     f1 = x6x3 + x5x1 + x4x2 + x1x0 + x0
+ *     f2 = x6x4x0 + x4x3x0 + x5x2 + x4x3 + x4x1 + x3x0 + x1
+ *     f3 = x5x4x0 + x6x4 + x5x2 + x3x0 + x1x0 + x3
+ *     f4 = x6x4x2x0 + x6x5 + x4x3 + x3x2 + x1x0 + x2
+ *
+ * Key schedule (paper, section 2.2): the key fills a run of 16-bit double-bytes
+ * which is extended by a three-word nonlinear register seeded from constants
+ * Q(l,0..2) taken from the fractional part of sqrt(15):
+ *     T = majority(S2,S1,S0); T = ROTL16(T, 5); T = T + S2 + kb[i mod ldb]
+ *     kb[i] = T; (S2,S1,S0) = (S1,S0,T)
+ * NOTE: section 2.2 step 2(b) of the paper says "rotate T to the right by 5
+ * bits" while the legend of its Figure 3 says a cyclic left shift by 5. The
+ * figure is right: only the left rotation reproduces the paper's own
+ * certification vectors. The double-bytes are then packed into round keys in
+ * order and handed out as K1..K4, a quarter of the rounds each.
+ *
+ * BYTE ORDER: SPEED numbers everything from the least significant end while the
+ * paper prints hex most significant first. So t7 is the FIRST word group of a
+ * displayed block and t0 the last, bytes within a word are big-endian, and
+ * kb[0] is the LAST double-byte of the key.
+ *
+ * Decryption runs the passes and their rounds backwards, recovering the
+ * discarded tail word from the new head: subtract instead of add, and rotate
+ * left instead of right. The key schedule is unchanged.
+ *
+ * Broken by Hall, Kelsey, Rijmen, Schneier and Wagner (SAC'98); educational only.
+ */
+
 (function (root, factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD
@@ -31,293 +91,367 @@
 
   // Extract framework components
   const { RegisterAlgorithm, CategoryType, SecurityStatus, ComplexityType, CountryCode,
-          BlockCipherAlgorithm, IBlockCipherInstance, LinkItem, KeySize } = AlgorithmFramework;
+          BlockCipherAlgorithm, IBlockCipherInstance, LinkItem, Vulnerability, KeySize } = AlgorithmFramework;
+
+  // ===== CONSTANTS =====
+
+  // Key-schedule seed constants Q(l, 0..2), from the fractional part of
+  // sqrt(15), one triple per key length 48, 64, 80, ... 256 bits.
+  const Q_CONSTANTS = [
+    [0xDF7B, 0xD629, 0xE9DB], // l = 48
+    [0x362F, 0x5D00, 0xF20F], // l = 64
+    [0xC3D1, 0x1FD2, 0x589B], // l = 80
+    [0x4312, 0x91EB, 0x718E], // l = 96
+    [0xBF2A, 0x1E7D, 0xB257], // l = 112
+    [0x77A6, 0x1654, 0x6B2A], // l = 128
+    [0x0D9B, 0xA9D3, 0x668F], // l = 144
+    [0x19BE, 0xF855, 0x6D98], // l = 160
+    [0x022D, 0xE4E2, 0xD017], // l = 176
+    [0xEA2F, 0x7572, 0xC3B5], // l = 192
+    [0x1086, 0x480C, 0x3AA6], // l = 208
+    [0x9CA0, 0x98F7, 0xD0E4], // l = 224
+    [0x253C, 0xC901, 0x55F3], // l = 240
+    [0x9BF4, 0xF659, 0xD76C]  // l = 256
+  ];
+
+  // Recommended round counts (paper, Table 1) keyed by block width in bits.
+  const DEFAULT_ROUNDS = { 64: 64, 128: 48, 256: 48 };
+
+  // ===== WORD HELPERS =====
+
+  function rotL(value, amount, wordBits, fullMask) {
+    const n = ((amount % wordBits) + wordBits) % wordBits;
+    const masked = OpCodes.And32(value, fullMask);
+    if (n === 0) return masked;
+    return OpCodes.And32(OpCodes.Or32(OpCodes.Shl32(masked, n), OpCodes.Shr32(masked, wordBits - n)), fullMask);
+  }
+
+  function rotR(value, amount, wordBits, fullMask) {
+    const n = ((amount % wordBits) + wordBits) % wordBits;
+    return rotL(value, wordBits - n, wordBits, fullMask);
+  }
+
+  // ===== BOOLEAN COMBINING FUNCTIONS (paper, section 4.2) =====
+  // t[i] is x_i; t[7] never participates, it is folded in separately.
+
+  function f1(t) {
+    let r = OpCodes.And32(t[6], t[3]);
+    r = OpCodes.Xor32(r, OpCodes.And32(t[5], t[1]));
+    r = OpCodes.Xor32(r, OpCodes.And32(t[4], t[2]));
+    r = OpCodes.Xor32(r, OpCodes.And32(t[1], t[0]));
+    return OpCodes.Xor32(r, t[0]);
+  }
+
+  function f2(t) {
+    let r = OpCodes.And32(OpCodes.And32(t[6], t[4]), t[0]);
+    r = OpCodes.Xor32(r, OpCodes.And32(OpCodes.And32(t[4], t[3]), t[0]));
+    r = OpCodes.Xor32(r, OpCodes.And32(t[5], t[2]));
+    r = OpCodes.Xor32(r, OpCodes.And32(t[4], t[3]));
+    r = OpCodes.Xor32(r, OpCodes.And32(t[4], t[1]));
+    r = OpCodes.Xor32(r, OpCodes.And32(t[3], t[0]));
+    return OpCodes.Xor32(r, t[1]);
+  }
+
+  function f3(t) {
+    let r = OpCodes.And32(OpCodes.And32(t[5], t[4]), t[0]);
+    r = OpCodes.Xor32(r, OpCodes.And32(t[6], t[4]));
+    r = OpCodes.Xor32(r, OpCodes.And32(t[5], t[2]));
+    r = OpCodes.Xor32(r, OpCodes.And32(t[3], t[0]));
+    r = OpCodes.Xor32(r, OpCodes.And32(t[1], t[0]));
+    return OpCodes.Xor32(r, t[3]);
+  }
+
+  function f4(t) {
+    let r = OpCodes.And32(OpCodes.And32(OpCodes.And32(t[6], t[4]), t[2]), t[0]);
+    r = OpCodes.Xor32(r, OpCodes.And32(t[6], t[5]));
+    r = OpCodes.Xor32(r, OpCodes.And32(t[4], t[3]));
+    r = OpCodes.Xor32(r, OpCodes.And32(t[3], t[2]));
+    r = OpCodes.Xor32(r, OpCodes.And32(t[1], t[0]));
+    return OpCodes.Xor32(r, t[2]);
+  }
+
+  const PASS_FUNCTIONS = [f1, f2, f3, f4];
 
   // ===== ALGORITHM IMPLEMENTATION =====
 
-class SPEED extends BlockCipherAlgorithm {
-  constructor() {
-    super();
+  class SPEED extends BlockCipherAlgorithm {
+    constructor() {
+      super();
 
-    this.name = "SPEED";
-    this.description = "Educational implementation of the SPEED cipher by Yuliang Zheng, designed for high performance with variable parameters and simple operations.";
-    this.inventor = "Yuliang Zheng";
-    this.year = 1997;
-    this.category = CategoryType.BLOCK;
-    this.subCategory = "Block Cipher";
-    this.securityStatus = SecurityStatus.INSECURE;
-    this.complexity = ComplexityType.INTERMEDIATE;
-    this.country = CountryCode.AU;
+      this.name = "SPEED";
+      this.description = "Unbalanced Feistel network by Yuliang Zheng over a queue of eight words. Each round builds one new word from a nonlinear Boolean combination of the other seven, rotates it by an amount derived from itself, and folds in the discarded tail word and a round key. Block width 64, 128 or 256 bits; key any multiple of 16 bits from 48 to 256; round count any multiple of 4 from 32 up.";
+      this.inventor = "Yuliang Zheng";
+      this.year = 1997;
+      this.category = CategoryType.BLOCK;
+      this.subCategory = "Block Cipher";
+      this.securityStatus = SecurityStatus.INSECURE;
+      this.complexity = ComplexityType.INTERMEDIATE;
+      this.country = CountryCode.AU;
 
-    this.SupportedKeySizes = [new KeySize(6, 32, 2)];
-    this.SupportedBlockSizes = [new KeySize(16, 16, 1)];
+      this.SupportedKeySizes = [new KeySize(6, 32, 2)];
+      this.SupportedBlockSizes = [new KeySize(8, 8, 1), new KeySize(16, 16, 1), new KeySize(32, 32, 1)];
 
-    this.documentation = [
-      new LinkItem("SPEED Cipher Paper", "https://link.springer.com/chapter/10.1007/3-540-63594-7_68")
-    ];
+      this.documentation = [
+        new LinkItem("The SPEED Cipher (Financial Cryptography '97, LNCS 1318)", "https://ifca.ai/pub/fc97/m6.pdf")
+      ];
 
-    this.references = [
-      new LinkItem("Yuliang Zheng SPEED C Reference (Applied Cryptography source code archive)", "https://www.schneier.com/books/applied-cryptography-source/"),
-      new LinkItem("embeddedsw.net libObfuscate SPEED Implementation", "https://embeddedsw.net/Cipher_Reference_Home.html")
-    ];
+      this.references = [
+        new LinkItem("Cryptanalysis of SPEED (Hall, Kelsey, Rijmen, Schneier, Wagner; SAC'98)", "https://www.schneier.com/wp-content/uploads/2016/02/paper-speed-sac.pdf")
+      ];
 
-    this.tests = [
-      {
-        text: "SPEED Test Vector 1",
-        uri: "Educational test vector for SPEED cipher",
-        input: OpCodes.Hex8ToBytes('00112233445566778899AABBCCDDEEFF'),
-        key: OpCodes.Hex8ToBytes('0F0E0D0C0B0A0908'),
-        expected: OpCodes.Hex8ToBytes('37A28C77C8F90B28020F08138A5112BB')
-      }
-    ];
+      this.knownVulnerabilities = [
+        new Vulnerability("Broken by differential and related-key attacks", "Hall, Kelsey, Rijmen, Schneier and Wagner broke the cipher at every published parameter set, including a differential attack on the full 48-round 128-bit version.", "Use AES or another vetted cipher.")
+      ];
+
+      // The three certification vectors printed in the paper's own appendix,
+      // "Certification Data for SPEED". Note the round counts: they use
+      // r = w rather than the recommended values, so each vector sets its own.
+      this.tests = [
+        {
+          text: "Paper certification data — w=64, l=64, r=64",
+          uri: "https://ifca.ai/pub/fc97/m6.pdf",
+          input: OpCodes.Hex8ToBytes('0000000000000000'),
+          key: OpCodes.Hex8ToBytes('0000000000000000'),
+          blockSize: 8,
+          rounds: 64,
+          expected: OpCodes.Hex8ToBytes('2e008019bc26856d')
+        },
+        {
+          text: "Paper certification data — w=128, l=128, r=128",
+          uri: "https://ifca.ai/pub/fc97/m6.pdf",
+          input: OpCodes.Hex8ToBytes('ffffffffffffffffffffffffffffffff'),
+          key: OpCodes.Hex8ToBytes('ffffffffffffffffffffffffffffffff'),
+          blockSize: 16,
+          rounds: 128,
+          expected: OpCodes.Hex8ToBytes('6c13e4b9c3171571ab54d816915bc4e8')
+        },
+        {
+          text: "Paper certification data — w=256, l=256, r=256",
+          uri: "https://ifca.ai/pub/fc97/m6.pdf",
+          input: OpCodes.Hex8ToBytes('1f1e1d1c1b1a191817161514131211100f0e0d0c0b0a09080706050403020100'),
+          key: OpCodes.Hex8ToBytes('605f5e5d5c5b5a595857565554535251504f4e4d4c4b4a494847464544434241'),
+          blockSize: 32,
+          rounds: 256,
+          expected: OpCodes.Hex8ToBytes('3de16cfa9a626847434e1574693fec1b3faa558a296b61d708b131ccba311068')
+        }
+      ];
+    }
+
+    CreateInstance(isInverse = false) {
+      return new SPEEDInstance(this, isInverse);
+    }
   }
 
-  CreateInstance(isInverse = false) {
-    return new SPEEDInstance(this, isInverse);
-  }
-}
-
-class SPEEDInstance extends IBlockCipherInstance {
-  constructor(algorithm, isInverse = false) {
-    super(algorithm);
-    this.isInverse = isInverse;
-    this.inputBuffer = [];
-    this._key = null;
-    this._expandedKey = null;
-    this._rounds = 32;
-  }
-
-  set key(keyBytes) {
-    if (!keyBytes) {
+  class SPEEDInstance extends IBlockCipherInstance {
+    constructor(algorithm, isInverse = false) {
+      super(algorithm);
+      this.isInverse = isInverse;
+      this.inputBuffer = [];
       this._key = null;
-      this._expandedKey = null;
-      return;
+      this._blockSize = 16;   // bytes; w = 128 bits
+      this._rounds = null;    // null means "use the recommended count for w"
+      this._roundKeys = null;
+      this.BlockSize = 16;
+      this.KeySize = 0;
     }
 
-    const isValidSize = this.algorithm.SupportedKeySizes.some(ks =>
-      keyBytes.length >= ks.minSize && keyBytes.length <= ks.maxSize
-    );
-
-    if (!isValidSize) {
-      throw new Error(`Invalid key size: ${keyBytes.length} bytes`);
-    }
-
-    this._key = [...keyBytes];
-    this._rounds = Math.max(32, (keyBytes.length * 4));
-    this._expandedKey = this._expandKey(keyBytes);
-  }
-
-  get key() { return this._key ? [...this._key] : null; }
-
-  Feed(data) {
-    if (!data || data.length === 0) return;
-    if (!this._key) throw new Error("Key not set");
-    for (let _i = 0; _i < data.length; _i++) this.inputBuffer.push(data[_i]);
-  }
-
-  Result() {
-    if (!this._key) throw new Error("Key not set");
-    if (this.inputBuffer.length === 0) throw new Error("No data fed");
-
-    const output = [];
-    const blockSize = 16;
-
-    for (let i = 0; i < this.inputBuffer.length; i += blockSize) {
-      const block = this.inputBuffer.slice(i, i + blockSize);
-      if (block.length !== blockSize) {
-        throw new Error(`Incomplete block: ${block.length} bytes`);
+    set key(keyBytes) {
+      if (!keyBytes) {
+        this._key = null;
+        this._roundKeys = null;
+        this.KeySize = 0;
+        return;
       }
 
-      const processedBlock = this.isInverse ?
-        this._decryptBlock(block) :
-        this._encryptBlock(block);
+      const isValidSize = this.algorithm.SupportedKeySizes.some(ks =>
+        keyBytes.length >= ks.minSize && keyBytes.length <= ks.maxSize
+        && (ks.stepSize === 0 || (keyBytes.length - ks.minSize) % ks.stepSize === 0)
+      );
 
-      for (let _i = 0; _i < processedBlock.length; _i++) output.push(processedBlock[_i]);
-    }
-
-    this.inputBuffer = [];
-    return output;
-  }
-
-  _expandKey(key) {
-    const expandedSize = this._rounds * 16;
-    const expanded = new Uint8Array(expandedSize);
-
-    for (let i = 0; i < expandedSize; i++) {
-      const baseValue = key[i % key.length];
-      const roundIndex = Math.floor(i / 16);
-      const byteIndex = i % 16;
-
-      expanded[i] = OpCodes.XorN(OpCodes.XorN(baseValue, OpCodes.AndN(roundIndex, 0xFF)), (byteIndex * 7));
-      expanded[i] = OpCodes.RotL8(expanded[i], (i % 8) + 1);
-
-      if (i > 0) {
-        expanded[i] = OpCodes.XorN(expanded[i], expanded[i - 1]);
-      }
-      if (i >= 16) {
-        expanded[i] = OpCodes.XorN(expanded[i], expanded[i - 16]);
-      }
-    }
-
-    return expanded;
-  }
-
-  _encryptBlock(data) {
-    const state = new Uint8Array(data);
-
-    for (let round = 0; round < this._rounds; round += 4) {
-      this._speedRound(state, round);
-      this._speedRound(state, round + 1);
-      this._speedRound(state, round + 2);
-      this._speedRound(state, round + 3);
-
-      if ((round + 4) % 16 === 0) {
-        this._mixBytes(state);
-      }
-    }
-
-    return state;
-  }
-
-  _decryptBlock(data) {
-    const state = new Uint8Array(data);
-
-    for (let round = this._rounds - 4; round >= 0; round -= 4) {
-      if ((round + 4) % 16 === 0) {
-        this._invMixBytes(state);
+      if (!isValidSize) {
+        throw new Error(`Invalid key size: ${keyBytes.length} bytes`);
       }
 
-      this._invSpeedRound(state, round + 3);
-      this._invSpeedRound(state, round + 2);
-      this._invSpeedRound(state, round + 1);
-      this._invSpeedRound(state, round);
+      this._key = [...keyBytes];
+      this.KeySize = keyBytes.length;
+      this._roundKeys = null; // rebuilt lazily: it depends on blockSize and rounds too
     }
 
-    return state;
-  }
+    get key() { return this._key ? [...this._key] : null; }
 
-  _speedRound(state, round) {
-    const keyOffset = round * 16;
+    set blockSize(bytes) {
+      if (bytes !== 8 && bytes !== 16 && bytes !== 32)
+        throw new Error(`Invalid block size: ${bytes} bytes. SPEED supports 8, 16 or 32`);
+      this._blockSize = bytes;
+      this.BlockSize = bytes;
+      this._roundKeys = null;
+    }
 
-    for (let i = 0; i < 16; i++) {
-      const keyByte = this._expandedKey[keyOffset + i];
-      const operation = OpCodes.AndN(keyByte, 0x03);
+    get blockSize() { return this._blockSize; }
 
-      switch (operation) {
-        case 0:
-          state[i] = OpCodes.XorN(state[i], keyByte);
-          break;
-        case 1:
-          state[i] = OpCodes.RotL8(state[i], OpCodes.AndN(OpCodes.Shr32(keyByte, 2), 0x07));
-          break;
-        case 2:
-          state[i] = this._substitute(state[i], keyByte);
-          break;
-        case 3:
-          const neighbor = (i + 1) % 16;
-          state[i] = OpCodes.XorN(state[i], state[neighbor]);
-          break;
+    set rounds(count) {
+      if (count === null || count === undefined) { this._rounds = null; this._roundKeys = null; return; }
+      if (count < 32 || count % 4 !== 0)
+        throw new Error(`Invalid round count: ${count}. SPEED requires a multiple of 4, at least 32`);
+      this._rounds = count;
+      this._roundKeys = null;
+    }
+
+    get rounds() { return this._rounds === null ? DEFAULT_ROUNDS[this._blockSize * 8] : this._rounds; }
+
+    Feed(data) {
+      if (!data || data.length === 0) return;
+      if (!this._key) throw new Error("Key not set");
+      for (let _i = 0; _i < data.length; _i++) this.inputBuffer.push(data[_i]);
+    }
+
+    Result() {
+      if (!this._key) throw new Error("Key not set");
+      if (this.inputBuffer.length === 0) throw new Error("No data fed");
+      if (this.inputBuffer.length % this._blockSize !== 0)
+        throw new Error(`Input length must be a multiple of ${this._blockSize} bytes`);
+
+      if (!this._roundKeys) this._roundKeys = this._expandKey();
+
+      const output = [];
+      for (let i = 0; i < this.inputBuffer.length; i += this._blockSize) {
+        const block = this.inputBuffer.slice(i, i + this._blockSize);
+        const processed = this.isInverse ? this._decryptBlock(block) : this._encryptBlock(block);
+        for (let _i = 0; _i < processed.length; _i++) output.push(processed[_i]);
       }
+
+      this.inputBuffer = [];
+      return output;
     }
 
-    for (let i = 0; i < 8; i++) {
-      const temp = state[i];
-      state[i] = state[i + 8];
-      state[i + 8] = temp;
+    // Geometry of the current parameter set.
+    _shape() {
+      const blockBits = this._blockSize * 8;
+      const wordBits = blockBits / 8;            // 8, 16 or 32
+      const wordBytes = wordBits / 8;            // 1, 2 or 4
+      const fullMask = wordBits === 32 ? 0xFFFFFFFF : OpCodes.Shl32(1, wordBits) - 1;
+      const halfBits = wordBits / 2;             // 4, 8 or 16
+      const halfMask = OpCodes.Shl32(1, halfBits) - 1;
+      // vv must span the whole 0..wordBits-1 rotation range, so the half-word is
+      // shifted down to leave exactly log2(wordBits) bits: 1, 4 and 11.
+      const vvShift = halfBits - Math.log2(wordBits);
+      return { blockBits, wordBits, wordBytes, fullMask, halfBits, halfMask, vvShift, fixedRotate: halfBits - 1 };
     }
-  }
 
-  _invSpeedRound(state, round) {
-    for (let i = 0; i < 8; i++) {
-      const temp = state[i];
-      state[i] = state[i + 8];
-      state[i + 8] = temp;
-    }
+    _expandKey() {
+      const { blockBits, wordBits, fullMask } = this._shape();
+      const rounds = this.rounds;
+      const keyBits = this._key.length * 8;
+      const ldb = keyBits / 16;                  // key length in 16-bit double-bytes
+      const q = Q_CONSTANTS[(keyBits - 48) / 16];
+      if (!q) throw new Error(`No key-schedule constants for a ${keyBits}-bit key`);
 
-    const keyOffset = round * 16;
+      // Number of double-bytes the round keys consume.
+      const last = blockBits === 64 ? rounds / 2 : (blockBits === 128 ? rounds : rounds * 2);
 
-    for (let i = 15; i >= 0; i--) {
-      const keyByte = this._expandedKey[keyOffset + i];
-      const operation = OpCodes.AndN(keyByte, 0x03);
-
-      switch (operation) {
-        case 0:
-          state[i] = OpCodes.XorN(state[i], keyByte);
-          break;
-        case 1:
-          state[i] = OpCodes.RotR8(state[i], OpCodes.AndN(OpCodes.Shr32(keyByte, 2), 0x07));
-          break;
-        case 2:
-          state[i] = this._invSubstitute(state[i], keyByte);
-          break;
-        case 3:
-          const neighbor = (i + 1) % 16;
-          state[i] = OpCodes.XorN(state[i], state[neighbor]);
-          break;
+      // Step 1: the key itself, read from the least significant end - kb[0] is
+      // the LAST double-byte printed, kb[ldb-1] the first.
+      const kb = new Array(Math.max(last, ldb));
+      for (let i = 0; i < ldb; ++i) {
+        const at = (ldb - 1 - i) * 2;
+        kb[i] = OpCodes.Or32(OpCodes.Shl32(this._key[at], 8), this._key[at + 1]);
       }
-    }
-  }
 
-  _substitute(byte, key) {
-    let result = byte;
-    result = OpCodes.XorN(result, OpCodes.RotL8(result, 1));
-    result = OpCodes.XorN(result, OpCodes.RotL8(result, 3));
-    result = OpCodes.XorN(result, key);
-    result = OpCodes.AndN(OpCodes.XorN((result * 3), OpCodes.Shr32(result, 2)), 0xFF);
-    return result;
-  }
-
-  _invSubstitute(byte, key) {
-    for (let i = 0; i < 256; i++) {
-      if (this._substitute(i, key) === byte) {
-        return i;
+      // Step 2: extend with the nonlinear register.
+      let s0 = q[0], s1 = q[1], s2 = q[2];
+      for (let i = ldb; i < last; ++i) {
+        const majority = OpCodes.Xor32(OpCodes.Xor32(OpCodes.And32(s2, s1), OpCodes.And32(s1, s0)), OpCodes.And32(s0, s2));
+        const rotated = rotL(majority, 5, 16, 0xFFFF);
+        const next = OpCodes.And32(OpCodes.Add32(OpCodes.Add32(rotated, s2), kb[i % ldb]), 0xFFFF);
+        kb[i] = next;
+        s2 = s1; s1 = s0; s0 = next;
       }
+
+      // Step 3: pack the double-byte stream into round keys, least significant
+      // double-byte first within a word.
+      const rk = new Array(rounds);
+      if (wordBits === 8) {
+        for (let i = 0; i < rounds / 2; ++i) {
+          rk[2 * i] = OpCodes.And32(kb[i], 0xFF);
+          rk[2 * i + 1] = OpCodes.And32(OpCodes.Shr32(kb[i], 8), 0xFF);
+        }
+      } else if (wordBits === 16) {
+        for (let i = 0; i < rounds; ++i) rk[i] = kb[i];
+      } else {
+        for (let i = 0; i < rounds; ++i)
+          rk[i] = OpCodes.And32(OpCodes.Or32(OpCodes.Shl32(kb[2 * i + 1], 16), kb[2 * i]), fullMask);
+      }
+      return rk;
     }
-    return byte;
+
+    // t7 is the FIRST word group of the block and t0 the last; bytes within a
+    // word are big-endian.
+    _loadBlock(block) {
+      const { wordBytes, fullMask } = this._shape();
+      const t = new Array(8);
+      for (let i = 0; i < 8; ++i) {
+        const at = (7 - i) * wordBytes;
+        let value = 0;
+        for (let b = 0; b < wordBytes; ++b) value = OpCodes.Or32(OpCodes.Shl32(value, 8), block[at + b]);
+        t[i] = OpCodes.And32(value, fullMask);
+      }
+      return t;
+    }
+
+    _storeBlock(t) {
+      const { wordBytes } = this._shape();
+      const out = new Array(this._blockSize);
+      for (let i = 0; i < 8; ++i) {
+        const at = (7 - i) * wordBytes;
+        for (let b = 0; b < wordBytes; ++b)
+          out[at + b] = OpCodes.And32(OpCodes.Shr32(t[i], (wordBytes - 1 - b) * 8), 0xFF);
+      }
+      return out;
+    }
+
+    _encryptBlock(block) {
+      const { wordBits, fullMask, halfBits, halfMask, vvShift, fixedRotate } = this._shape();
+      const rk = this._roundKeys;
+      const rounds = this.rounds;
+      const perPass = rounds / 4;
+      let t = this._loadBlock(block);
+
+      for (let n = 0; n < rounds; ++n) {
+        const combine = PASS_FUNCTIONS[Math.floor(n / perPass)];
+        const tail = rotR(t[7], fixedRotate, wordBits, fullMask);
+        let tmp = OpCodes.And32(combine(t), fullMask);
+        const vv = OpCodes.Shr32(OpCodes.And32(OpCodes.Add32(OpCodes.Shr32(tmp, halfBits), tmp), halfMask), vvShift);
+        tmp = rotR(tmp, vv, wordBits, fullMask);
+        const head = OpCodes.And32(OpCodes.Add32(OpCodes.Add32(tail, tmp), rk[n]), fullMask);
+        t = [head, t[0], t[1], t[2], t[3], t[4], t[5], t[6]];
+      }
+
+      return this._storeBlock(t);
+    }
+
+    _decryptBlock(block) {
+      const { wordBits, fullMask, halfBits, halfMask, vvShift, fixedRotate } = this._shape();
+      const rk = this._roundKeys;
+      const rounds = this.rounds;
+      const perPass = rounds / 4;
+      let t = this._loadBlock(block);
+
+      for (let n = rounds - 1; n >= 0; --n) {
+        // Everything except the tail word is simply the queue shifted back one
+        // place; the tail is what the round consumed into the new head.
+        const previous = [t[1], t[2], t[3], t[4], t[5], t[6], t[7], 0];
+        const combine = PASS_FUNCTIONS[Math.floor(n / perPass)];
+        let tmp = OpCodes.And32(combine(previous), fullMask);
+        const vv = OpCodes.Shr32(OpCodes.And32(OpCodes.Add32(OpCodes.Shr32(tmp, halfBits), tmp), halfMask), vvShift);
+        tmp = rotR(tmp, vv, wordBits, fullMask);
+        const tail = OpCodes.And32(OpCodes.Sub32(OpCodes.Sub32(t[0], tmp), rk[n]), fullMask);
+        previous[7] = rotL(tail, fixedRotate, wordBits, fullMask);
+        t = previous;
+      }
+
+      return this._storeBlock(t);
+    }
   }
-
-  _mixBytes(state) {
-    for (let i = 0; i < 4; i++) {
-      const offset = i * 4;
-      const a = state[offset];
-      const b = state[offset + 1];
-      const c = state[offset + 2];
-      const d = state[offset + 3];
-
-      state[offset] = OpCodes.XorN(OpCodes.XorN(a, b), c);
-      state[offset + 1] = OpCodes.XorN(OpCodes.XorN(a, b), d);
-      state[offset + 2] = OpCodes.XorN(OpCodes.XorN(a, c), d);
-      state[offset + 3] = OpCodes.XorN(OpCodes.XorN(b, c), d);
-    }
-
-    const temp = state[0];
-    for (let i = 0; i < 15; i++) {
-      state[i] = state[i + 1];
-    }
-    state[15] = temp;
-  }
-
-  _invMixBytes(state) {
-    const temp = state[15];
-    for (let i = 15; i > 0; i--) {
-      state[i] = state[i - 1];
-    }
-    state[0] = temp;
-
-    for (let i = 0; i < 4; i++) {
-      const offset = i * 4;
-      const a = state[offset];
-      const b = state[offset + 1];
-      const c = state[offset + 2];
-      const d = state[offset + 3];
-
-      state[offset] = OpCodes.XorN(OpCodes.XorN(a, b), c);
-      state[offset + 1] = OpCodes.XorN(OpCodes.XorN(a, b), d);
-      state[offset + 2] = OpCodes.XorN(OpCodes.XorN(a, c), d);
-      state[offset + 3] = OpCodes.XorN(OpCodes.XorN(b, c), d);
-    }
-  }
-}
 
   // ===== REGISTRATION =====
 

--- a/Cipher/tests/RoundTripSuite.js
+++ b/Cipher/tests/RoundTripSuite.js
@@ -457,7 +457,6 @@ const ROUND_TRIP_EXEMPT = new Map([
   ['SATURNIN-Short', 'open defect: decryption does not invert encryption (TestSuite reports 0/1)'],
   // Found by this sweep rather than by the vectors, and left recorded rather
   // than silently dropped, because each needs work beyond a decryption fix.
-  ['HPC', 'open defect: variable-length block handling does not round-trip away from the vector'],
   ['Fubuki (DarkCrypt)', 'open defect: does not round-trip on input longer than one keystream block'],
   ['FF3', 'open defect: accepts none of the lengths its own radix admits'],
 ]);

--- a/Cipher/tests/RoundTripSuite.js
+++ b/Cipher/tests/RoundTripSuite.js
@@ -448,7 +448,6 @@ const ROUND_TRIP_EXEMPT = new Map([
   // switched off. Each needs its decryption path repaired on its own merits.
   ['ForkSkinny-128-256', 'open defect: decryption does not invert encryption (TestSuite reports 0/2)'],
   ['ForkSkinny-128-384', 'open defect: decryption does not invert encryption (TestSuite reports 0/2)'],
-  ['FROG', 'open defect: decryption does not invert encryption (TestSuite reports 0/1)'],
   ['Hierocrypt-3', 'open defect: decryption does not invert encryption (TestSuite reports 0/1)'],
   ['SC2000', 'open defect: decryption does not invert encryption (TestSuite reports 0/1)'],
   ['SKINNY-128', 'open defect: decryption does not invert encryption (TestSuite reports 0/2)'],

--- a/Cipher/tests/RoundTripSuite.js
+++ b/Cipher/tests/RoundTripSuite.js
@@ -450,7 +450,6 @@ const ROUND_TRIP_EXEMPT = new Map([
   ['ForkSkinny-128-384', 'open defect: decryption does not invert encryption (TestSuite reports 0/2)'],
   ['Hierocrypt-3', 'open defect: decryption does not invert encryption (TestSuite reports 0/1)'],
   ['SKINNY-128', 'open defect: decryption does not invert encryption (TestSuite reports 0/2)'],
-  ['SPEED', 'open defect: decryption does not invert encryption (TestSuite reports 0/1)'],
   ['LOTUS-AEAD', 'open defect: decryption does not invert encryption (TestSuite reports 0/3)'],
   ['SATURNIN-Short', 'open defect: decryption does not invert encryption (TestSuite reports 0/1)'],
   // Found by this sweep rather than by the vectors, and left recorded rather

--- a/Cipher/tests/RoundTripSuite.js
+++ b/Cipher/tests/RoundTripSuite.js
@@ -449,7 +449,6 @@ const ROUND_TRIP_EXEMPT = new Map([
   ['ForkSkinny-128-256', 'open defect: decryption does not invert encryption (TestSuite reports 0/2)'],
   ['ForkSkinny-128-384', 'open defect: decryption does not invert encryption (TestSuite reports 0/2)'],
   ['Hierocrypt-3', 'open defect: decryption does not invert encryption (TestSuite reports 0/1)'],
-  ['SC2000', 'open defect: decryption does not invert encryption (TestSuite reports 0/1)'],
   ['SKINNY-128', 'open defect: decryption does not invert encryption (TestSuite reports 0/2)'],
   ['SPEED', 'open defect: decryption does not invert encryption (TestSuite reports 0/1)'],
   ['LOTUS-AEAD', 'open defect: decryption does not invert encryption (TestSuite reports 0/3)'],


### PR DESCRIPTION
Four algorithms whose decryption had never worked. Three turned out not to be the
ciphers they named.

## FROG, SC2000, SPEED — fabrications, reimplemented from specification

None of these was the named cipher, and each was **provably not injective**, so
there was no decryption to repair — only an encryption that discarded
information. Each committed vector carried `uri: "Educational test vector for …"`,
a fingerprint of the fabrication rather than a source.

- **SC2000** — the final layer collapsed 16 bits of state to 6
  (`S5[x&0x1F] ^ S6[(x>>5)&0x3F]` never exceeds `0x3F`), so eight output bytes
  were constant zero. Its "6-bit S-box" is not a permutation. Explicit collision
  found.
- **SPEED** — `_substitute` opens with `x XOR ROTL8(x,1)`, singular over GF(2)
  with kernel `{0x00, 0xFF}`; the image covers 60–62 of 256 values for *every*
  key byte. Explicit collision found.
- **FROG** — its substitution is a bijection for only 2 of 256 key values, and 40
  of 128 byte-operations used a non-bijective one. At round 3, byte 1, the
  committed key forces a byte to `0x00`.

All three are reimplemented from their specifications and validated against
**official** vectors, not self-generated ones:

| cipher | source | result |
|---|---|---|
| FROG | AES submission `ecb_vk.txt` / `ecb_vt.txt`, 22 entries at 128 bits plus the 192/256-bit variable-key entries, and the plugin's three vectors | 0/1 → **10/10** |
| SC2000 | CRYPTREC specification's worked example (intermediate words and `EXKEY[0..7]`, `EXKEY[52..55]`), Fujitsu NESSIE vectors at 128/192/256, both the 100- and 1000-iteration chains | 0/1 → **7/7** |
| SPEED | FC'97 paper (LNCS 1318), all three certification vectors including the 256-bit one that pins every byte-order convention | 0/1 → **3/3** |

One specification conflict is recorded in the file rather than silently resolved:
SPEED's §2.2 says the key schedule rotates *right* by 5 while Figure 3 says
*left*. Only left reproduces the paper's own vectors.

## HPC — a real implementation with five defects

Its five committed vectors exercise only the Tiny and Short sub-ciphers, so four
of the five sub-ciphers could not decrypt and nothing noticed.

- The round function keeps the block's **last** word in `s7` — that is why `s7`
  is the one masked with `lmask` — but `s7` was bound to `state[7]` regardless of
  width, so below 449 bits the real last word was never transformed. All 320
  block sizes from 129–448 bits failed; 449–511 passed by coincidence.
- `packBytesToState` skipped its trailing-word branch at exactly 512 bits, and
  `unpackStateToBytes` read the tail from word 7 for every block wider than 128.
- The nibble permutations are indexed by a shift of `4*v`, but all eight call
  sites computed `v & (15<<2)` instead of `(v & 15) << 2` — reaching 4 of 16
  nibbles, a four-to-one map.
- Tiny 5/6-bit decryption recovered the key-stream **stride** (`2*blockSize-1`)
  rather than its **span** (`2*blockSize`), losing the addend's top bit.
- Blocks wider than 512 bits lost their first eight words to the output and
  returned early from the sub-cipher switch, skipping post-KX whitening on
  encryption only.

Verified over **10,812 cases** — byte lengths 1–600 across four key sizes and
three patterns, bit widths 1–1200. All five committed vectors unchanged. `Result`
now refuses input that is not exactly the declared block rather than truncating
it silently.

## Verification

- `RoundTripSuite.js` 615 passed, 0 failed, 19 exempt — all four exemptions removed
- `TestSuite.js` 5574/5574, exit 0, with no `Invertibility Requirement: ✗ FAILED`
  for any of the four

## Flagged

A C# transpilation regression was introduced for `frog.js` and `speed.js` and
then caught: four emitter limitations (array-of-records, bool-as-numeric argument,
a backing-field name collision, arrays of function references). The algorithms
were reworked rather than the shared emitter, and both compile again with
identical behaviour.

Pre-existing and not addressed: `hpc.js` has never compiled to C#, nor have
`darkcrypt-frog.js`, `darkcrypt-speed.js` or `darkcrypt-hpc.js` — confirmed by
transpiling the unmodified files.
